### PR TITLE
docs: add Contributor Covenant v2.1 Code of Conduct

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,13 @@
+*.sh        text eol=lf
+*.ps1       text eol=crlf
+*.md        text eol=lf
+*.json      text eol=lf
+*.yaml      text eol=lf
+*.yml       text eol=lf
+*.js        text eol=lf
+*.mjs       text eol=lf
+hooks/*.sh  text eol=lf
+*           text=auto
+
+# Test fixtures intentionally preserve their line endings
+tests/fixtures/config-crlf.md -text

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,47 +4,81 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main]
 
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+        with:
+          fetch-depth: 1
 
-      - name: Install jq
+      - name: Setup Node 20
+        uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af  # v4.1.0
+        with:
+          node-version: '20'
+          cache: npm
+
+      - name: Install jq (Linux)
+        if: runner.os == 'Linux'
         run: sudo apt-get install -y jq
 
-      - name: Verify environment
+      - name: Install jq (macOS)
+        if: runner.os == 'macOS'
+        run: brew install jq
+
+      - name: Verify environment (Unix)
+        if: runner.os != 'Windows'
+        shell: bash
         run: |
-          echo "=== Checking bash ==="
           bash --version | head -1
           bash_version=$(bash -c 'echo ${BASH_VERSINFO[0]}')
           if [ "$bash_version" -lt 4 ]; then
             echo "ERROR: bash 4+ required, found bash $bash_version"
             exit 1
           fi
-
-          echo "=== Checking git ==="
           git --version
           git config --global user.name "CI"
           git config --global user.email "ci@test.com"
-
-          echo "=== Checking jq ==="
           jq --version
 
-          echo "=== Checking temp directory ==="
-          tmpdir=$(mktemp -d)
-          [ -d "$tmpdir" ] && rm -rf "$tmpdir" || { echo "ERROR: mktemp failed"; exit 1; }
+      - name: Install Node dependencies
+        run: npm ci
 
-          echo "=== Checking /tmp writability ==="
-          touch /tmp/ci-write-test && rm /tmp/ci-write-test || { echo "ERROR: /tmp is not writable"; exit 1; }
+      - name: Lint
+        run: npm run lint
 
-          echo "=== All environment checks passed ==="
+      - name: Typecheck (.mjs files — Wave 3+)
+        shell: bash
+        run: |
+          if ls hooks/*.mjs scripts/lib/*.mjs 2>/dev/null | grep -q .; then
+            npm run typecheck
+          else
+            echo "No .mjs files yet (Wave 3 adds them) — skipping typecheck"
+          fi
 
-      - name: Run test suite
+      - name: Bash test suite (Unix only)
+        if: runner.os != 'Windows'
+        shell: bash
         run: bash scripts/test/run-all.sh
+
+      - name: Vitest
+        shell: bash
+        run: |
+          if [ -d tests ] && ls tests/**/*.test.mjs 2>/dev/null | grep -q .; then
+            npm test
+          else
+            echo "No vitest tests yet (Wave 4 adds them) — skipping"
+          fi

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ Thumbs.db
 .claude/STATE.md
 .claude/wave-scope.json
 .claude/metrics/
+.claude/worktrees/
 
 # Codex CLI runtime state (session orchestrator)
 .codex/STATE.md
@@ -29,3 +30,4 @@ Thumbs.db
 
 # Internal design specs (kept locally, not for public repo)
 docs/specs/
+.orchestrator/session-notes/

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,5 @@
+node_modules/
+.orchestrator/
+docs/
+package-lock.json
+*.md

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,11 @@
+{
+  "semi": true,
+  "singleQuote": true,
+  "printWidth": 100,
+  "tabWidth": 2,
+  "useTabs": false,
+  "trailingComma": "all",
+  "endOfLine": "lf",
+  "arrowParens": "always",
+  "bracketSpacing": true
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- session-start: reset STATE.md to idle when previous session completed — clears `current-wave`, sets `status: idle`, demotes `## Wave History` into `## Previous Session`, and empties `## Deviations`. Only triggers on the `completed` branch; `active`/`paused` paths remain user-interactive via AskUserQuestion. Prevents a fresh session from appearing "already completed". (closes infrastructure/projects-baseline#159)
+
 ## [2.0.0] - 2026-04-17
 
 First stable release of the 2.x line. Bundles six betas worth of work into a single stable cut.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,27 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [Unreleased]: 3.0.0-dev (Windows native foundation wave)
+
+Bash to Node.js (zx 8) migration kicks off. Epic #124. Foundation landed; hooks and test migration follow in subsequent sessions.
+
+### Added
+- `.gitattributes` (#125): cross-platform EOL rules. LF for `.sh`, `.md`, `.json`, `.yaml`, `.mjs`; CRLF for `.ps1`; `* text=auto` fallback. Prevents autocrlf breakage on Windows checkouts.
+- `package.json` + `package-lock.json` (#126): plugin-root Node 20+ manifest with `type: "module"`, zx ^8.1.0 dep, ESLint v9, Prettier v3, and vitest ^2 devDeps. `npm ci`-installable. Version bumped to `3.0.0-dev`.
+- ESLint v9 flat config + Prettier (#127): `eslint.config.js` with @eslint/js recommended, Node 20 globals, project rules (`no-unused-vars` with `_`-prefix allowlist, `prefer-const`, `no-var`, `eqeqeq`). `.prettierrc` uses single quotes, 100 columns, LF. `.prettierignore` excludes `*.md` because skill files have intentional formatting. Baseline green, `lint:fix` idempotent.
+- CI matrix for ubuntu, macos, and windows-latest (#128): `.github/workflows/test.yml` extends to a 3-OS matrix with `fail-fast: false`. Preserves v2.0 hardenings (least-privilege `permissions`, `timeout-minutes`, SHA-pinned actions). Adds concurrency group, conditional typecheck (gated on `.mjs` existence), jq install per-OS, vitest placeholder for Wave 4.
+- `scripts/lib/platform.mjs` (#129): Node port of `platform.sh` with Windows-safe filesystem walk (`path.parse(dir).root` replaces the Bash `/`-terminator that breaks on `C:\`). New exports: `SO_OS`, `SO_IS_WINDOWS`, `SO_IS_WSL`, `SO_PATH_SEP` alongside the six existing IDE/project constants. Five named helper functions for callers that need to re-detect.
+- `scripts/lib/path-utils.mjs` (#130): CWE-23-safe pure path helpers backing the forthcoming `enforce-scope.mjs`. Rejects null bytes, empty strings, UNC paths (Windows), prefix-match confusion, cross-drive escapes. Locale-stable case normalization via `toLocaleLowerCase('en-US')` to avoid Turkish-I-style regressions. Exports a documented `CWE_23_ATTACK_PATTERNS` taxonomy for test self-check.
+- `scripts/lib/config.mjs` (#132): Node port of `parse-config.sh` + `config-yaml-parser.sh` + `config-json-coercion.sh` combined into one module with private coercion helpers. CRLF-tolerant input, native JSON (no jq shellout). Byte-exact parity against the `.sh` version on the project's own `CLAUDE.md`.
+- vitest coverage for foundation libs: 142 tests across `tests/lib/{platform,path-utils,config}.test.mjs` plus 5 fixtures under `tests/fixtures/`. `path-utils` tests cover every documented CWE-23 vector and are falsification-verified. `config` tests include a subprocess-bash parity diff gated on non-Windows.
 
 ### Fixed
-- session-start: reset STATE.md to idle when previous session completed — clears `current-wave`, sets `status: idle`, demotes `## Wave History` into `## Previous Session`, and empties `## Deviations`. Only triggers on the `completed` branch; `active`/`paused` paths remain user-interactive via AskUserQuestion. Prevents a fresh session from appearing "already completed". (closes infrastructure/projects-baseline#159)
+- session-start: reset STATE.md to idle when previous session completed. Clears `current-wave`, sets `status: idle`, demotes `## Wave History` into `## Previous Session`, and empties `## Deviations`. Only triggers on the `completed` branch; `active` and `paused` paths remain user-interactive via AskUserQuestion. Prevents a fresh session from appearing "already completed". (closes infrastructure/projects-baseline#159)
+- Pre-v3 `.mjs` lint baseline: removed an unused `fileURLToPath` import, replaced `== null` with explicit `=== null || === undefined`, prefixed intentionally-unused destructures and params with `_`, cleaned a `no-useless-escape`. `npm run lint` is now idempotent on the full tree.
+
+### Migration
+- Developer prerequisite: Node 20+ and `npm ci` after clone. Existing bash test suite (`scripts/test/run-all.sh`) continues to work on Unix while the foundation stabilizes; Windows users run `npm test` only.
+- No user-visible breakage yet. Hook migrations in later waves will require `npm install` in the plugin directory before hooks fire.
 
 ## [2.0.0] - 2026-04-17
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,6 +43,17 @@ tools: Read, Grep, Glob, Bash  # COMMA-SEPARATED STRING, not JSON array!
 
 Reference: https://github.com/anthropics/claude-code/blob/main/plugins/plugin-dev/skills/agent-development/SKILL.md
 
+## v3.0 Migration (in progress)
+
+Bash → Node.js (zx 8) migration for native Windows support. Epic #124. Current
+branch: `feat/windows-native-v3`. Foundation wave (issues #125–#130, #132) landed;
+hook migrations (#137–#142) and test migration (#143–#145) pending in future
+sessions.
+
+Development prerequisite: **Node 20+**. Run `npm ci` after cloning. Test with
+`npm test` (vitest) plus `bash scripts/test/run-all.sh` (legacy shell suite —
+will be retired in a later wave). Lint: `npm run lint`.
+
 ## v2.0 Features
 
 - Session persistence via STATE.md + session memory files
@@ -62,8 +73,8 @@ Reference: https://github.com/anthropics/claude-code/blob/main/plugins/plugin-de
 persistence: true
 enforcement: warn
 recent-commits: 20
-test-command: for f in scripts/test/test-*.sh; do bash "$f" || exit 1; done
-typecheck-command: false
-lint-command: false
+test-command: npm test
+typecheck-command: npm run typecheck
+lint-command: npm run lint
 stale-branch-days: 7
 plugin-freshness-days: 30

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,84 @@
+
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, caste, color, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces. Examples of representing our community include using an official e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at office@gotzendorfer.at. All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time. This includes avoiding interactions in community spaces as well as external channels like social media. Violating these terms may lead to a temporary or permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public communication with the community for a specified period of time. No public or private interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, is allowed during this period. Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community standards, including sustained inappropriate behavior, harassment of an individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at [https://www.contributor-covenant.org/faq][FAQ]. Translations are available at [https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/docs/prd/2026-04-18-windows-native-support.md
+++ b/docs/prd/2026-04-18-windows-native-support.md
@@ -1,0 +1,396 @@
+# Feature: Windows Native Support (v3.0.0)
+
+**Date:** 2026-04-18
+**Author:** Bernhard Götzendorfer + Claude (AI-assisted planning)
+**Status:** Draft — Awaiting Approval
+**Appetite:** Full Migration (no time estimate per user direction)
+**Parent Project:** session-orchestrator (v2.0.0 → v3.0.0)
+
+---
+
+## 1. Problem & Motivation
+
+### What
+
+Der `session-orchestrator` Plugin läuft heute auf macOS und Linux zuverlässig, auf **nativem Windows (ohne WSL/Git-Bash-Hack) aber gar nicht**. Alle 5 Hooks sind fest auf `bash` verdrahtet (`bash "$CLAUDE_PLUGIN_ROOT/hooks/*.sh"`), ~50 Scripts verwenden POSIX-only Idioms (`/tmp`, Prefix-Stripping mit `/`, GNU `sed`/`date`/`jq`), und 47 `.sh`-Testscripts blockieren Windows-Contributors komplett.
+
+**Ziel:** Windows läuft **identisch wie macOS** — nativer Betrieb ohne WSL, ohne Git Bash, ohne manuelle Workarounds. Plugin-User unter Windows installieren einmal, Hooks funktionieren, Tests laufen, CI grün.
+
+Der Migrations-Pfad ist klar: **Kompletter Umstieg auf Node.js (zx 8.x) für allen ausgeführten Code** (Hooks + Scripts + Test-Runner). Markdown-Skills mit Bash-Snippets bleiben unverändert — das sind Prompt-Dokumentationen für das LLM, kein tatsächlich ausgeführter Code.
+
+### Why
+
+1. **User-Feedback:** Konkreter Report, dass Codex/Claude-Code-User auf Windows mit session-orchestrator "die ärgsten Probleme" haben.
+2. **Anthropic hat den Boden bereitet:** Claude Code v2.1.84 (März 2026) brachte den Opt-in-PowerShell-Tool; April-2026-Release fixte Drive-Letter-Case und SessionStart-Hooks auf Windows. Jetzt ist der realistische Zeitpunkt für Native-Support.
+3. **Marktplatz-Adoption:** Plugin ist im `kanevry`-Marketplace pending Anthropic-Review. Ein "Windows broken"-Label schadet der Erstwahrnehmung. ~30% der Developer-Userbase arbeitet auf Windows (Stack Overflow Survey 2025).
+4. **Wartungslast:** Bash-Scripts sind fragil (POSIX vs GNU sed, macOS `date` vs Linux `date`, `/tmp` vs `%TEMP%`). Node.js eliminiert diese Klasse von Bugs komplett (`os.tmpdir()`, `path.join()`, native JSON).
+5. **Known Upstream Bugs:** GitHub-Issues #22700 (bash-PATH), #23556 (WSL+Git-Bash-Konflikt), #34457 (subprocess-deadlocks), #18527 (Path-Separator) → alle durch Node.js-Hooks umgangen, weil `command: "node ..."` die bash-Resolution-Probleme bypasst.
+
+### Who
+
+1. **Primary: Native-Windows-Developer ohne WSL** — Corporate-IT-Umgebungen mit WSL-Verbot, Windows-First-Developer, Einsteiger die WSL-Setup als Hürde empfinden. Das ist der aktuell komplett blockierte Cohort.
+2. **Secondary: WSL2-User** — funktioniert heute halbwegs, wird durch Migration aber robuster (keine CRLF-Probleme mehr, keine jq-Abhängigkeit).
+3. **Tertiary: Unix-User (macOS/Linux)** — profitieren durch robustere Scripts, klarere Fehlermeldungen (Node-Stacktraces > Bash `set -e` abort), einheitliche Test-Story.
+4. **Plugin-Contributors unter Windows** — können zum ersten Mal nativ Tests laufen lassen (Vitest statt bats), lokal debuggen, beitragen.
+
+---
+
+## 2. Solution & Scope
+
+### In-Scope
+
+- [ ] **`.gitattributes`** (neu): LF für `.sh`, `.md`, `.json`, `.yaml`, `.yml`, `.mjs`, `.js`; CRLF für `.ps1`; `* text=auto` als Fallback.
+- [ ] **`package.json`** (neu, Plugin-Root): Node 20+ engines, `type: "module"`, `zx ^8.1.0` als dep, `vitest ^2.0.0` als devDep, Scripts `test`, `test:watch`, `lint`, `typecheck`.
+- [ ] **Alle 5 Hooks migriert von `.sh` nach `.mjs`** (Node + zx): `on-session-start`, `on-stop`, `enforce-scope`, `enforce-commands`, `post-edit-validate`.
+- [ ] **`hooks/hooks.json` aktualisiert** auf `"command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/<name>.mjs\""` für alle Hooks.
+- [ ] **Kritische Scripts migriert** von `.sh` nach `.mjs` — alle unter `scripts/` die nicht Tests sind: `parse-config.sh`, `lib/events.sh`, `lib/worktree.sh`, `lib/config-yaml-parser.sh`, `lib/platform.sh`, `lib/hardening.sh`, `lib/common.sh`.
+- [ ] **Test-Runner von `bats` auf `vitest`** migriert: alle 47 `scripts/test/test-*.sh` in `tests/*.test.mjs` übersetzt. Fokus auf Verhaltensäquivalenz, nicht 1:1-Übersetzung.
+- [ ] **GitHub Actions windows-latest + macos-latest + ubuntu-latest Matrix** ab Tag 1 des Branches.
+- [ ] **Platform-Detection erweitert** in `scripts/lib/platform.mjs`: OS-Detection (`process.platform`), Drive-Letter-Awareness, SO_OS-Export für Downstream-Use.
+- [ ] **Path-Handling-Helfer** in `scripts/lib/path-utils.mjs`: Containment-Check (path-traversal-safe), Relative-Path-Computation, Drive-Letter-Case-Normalization.
+- [ ] **`jq`-Dependency eliminiert** (~40 Stellen) durch native JS `JSON.parse()`/`JSON.stringify()`.
+- [ ] **`/tmp`-Hardcodes eliminiert** durch `os.tmpdir()`.
+- [ ] **POSIX-Prefix-Stripping** (`${PATH#"$ROOT"/}`) durch `path.relative()` ersetzt.
+- [ ] **README.md aktualisiert**: "Platform Support"-Tabelle klarstellen (Windows nativ ✅), Installation-Docs (`npm install`-Schritt), Troubleshooting-Section für Windows-spezifische Gotchas.
+- [ ] **CHANGELOG.md v3.0.0**: BREAKING-CHANGES-Section, Migration-Guide für Bestands-User.
+- [ ] **Migration-Guide** in `docs/migration-v3.md`: Was ändert sich für User (Node-Install nötig), für Contributors (Vitest statt bats), für Plugin-Entwickler (`.mjs` statt `.sh`).
+- [ ] **ESLint + Prettier Config** (flat config, v9): Basis-Regeln für `.mjs` files, CI-Check.
+
+### Out-of-Scope
+
+- **Skill-Markdown-Prompts mit Bash-Code-Blöcken bleiben unverändert** — das sind Prompts/Dokumentation für das LLM, nicht ausgeführter Code. Das LLM interpretiert sie sowieso platform-agnostisch. Eine Migration wäre reine Kosmetik mit YAGNI-Risiko und würde getestetes LLM-Verhalten brechen.
+- **PowerShell-Version der Hooks** (`.ps1`) — Dual-Shipping ist wartungsfeindlich (Drift). Node.js ersetzt beides sauber. `shell: "powershell"` im Hooks.json wird nur als optionale Escape-Hatch in Docs erwähnt, nicht als Primärpfad.
+- **WSL-Deprecation** — WSL-User profitieren automatisch, aber nichts wird für WSL spezifisch gebaut oder entfernt.
+- **Migration bestehender Sessions-History / Metrics** — Format (JSONL) bleibt identisch, keine Schema-Änderung.
+- **Neue Features** — keine zusätzliche Funktionalität. Dieser PRD ist reine Portabilitäts-Refaktorierung.
+- **TypeScript-Migration** — vorerst bleibt es bei `.mjs` mit JSDoc-Typisierung wo sinnvoll. TS ist separates Projekt.
+- **Shell-Script-Bundling mit `pkg`/`ncc`** — Single-Binary-Distribution wäre ein eigenes großes Projekt und nicht notwendig: `npm install` ist für Developer akzeptabel.
+- **Node-Version-Downgrade unter 20** — Node 20 LTS ist seit Oktober 2023 stabil; `AbortController`, Native Test Runner, stable Fetch brauchen wir.
+- **Codex-CLI-spezifische Abweichungen** — gleiche Node-basierte Hooks laufen in beiden Environments.
+
+---
+
+## 3. Acceptance Criteria
+
+### Bereich 1: Hooks laufen auf Windows nativ
+
+```gherkin
+Given ein Windows-11-System ohne WSL und ohne Git-for-Windows
+And Node.js 20+ ist installiert
+And der User hat `session-orchestrator` geklont und `npm install` im Plugin-Root ausgeführt
+When Claude Code startet und eine Session geöffnet wird
+Then der SessionStart-Hook läuft ohne Fehler durch
+And `.claude/STATE.md` wird korrekt gelesen/geschrieben
+And es erscheinen keine "bash: command not found" oder Path-Separator-Fehler im Transcript
+```
+
+### Bereich 2: Scope-Enforcement schützt korrekt cross-platform
+
+```gherkin
+Given eine Session mit aktivem wave-scope.json (`enforcement: strict`, `allowedPaths: ["src/**/*.ts"]`)
+When Claude versucht, `C:\Users\dev\project\src\index.ts` (Windows) zu editieren
+Then `enforce-scope.mjs` liest stdin, resolved Path via `path.resolve()`, matched gegen Pattern mit `path.relative()`
+And gibt `{"permissionDecision": "allow"}` zurück mit Exit-Code 0
+When Claude versucht, `C:\Users\dev\project\node_modules\foo.js` zu editieren
+Then Hook liefert `{"permissionDecision": "deny", "reason": "Scope violation: ..."}` mit Exit-Code 2
+```
+
+### Bereich 3: Path-Traversal-Schutz ist sicher
+
+```gherkin
+Given project-root `C:\Users\dev\project`
+When Claude versucht, `../../Windows/System32/hosts` zu editieren
+Then `enforce-scope.mjs` resolved zu `C:\Windows\System32\hosts`
+And `path.relative(projectRoot, fullPath)` startet mit `..` oder ist absolut
+And Hook liefert `deny` mit Reason "File outside project root"
+And auf macOS: gleicher Test mit `/etc/passwd` liefert ebenfalls `deny`
+```
+
+### Bereich 4: `jq`-Unabhängigkeit
+
+```gherkin
+Given ein Windows-System ohne `jq` im PATH
+When irgendein Hook oder Script ausgeführt wird, das früher `jq` verwendete (z.B. on-stop.mjs, enforce-commands.mjs)
+Then das Script parst JSON nativ mit `JSON.parse()` und `JSON.stringify()`
+And keine externe Binary wird aufgerufen
+And die funktionale Ausgabe ist identisch zu macOS
+```
+
+### Bereich 5: Tests laufen auf allen drei OS
+
+```gherkin
+Given der Developer hat das Repo gecloned und `npm install` ausgeführt
+When `npm test` auf macOS/Linux/Windows ausgeführt wird
+Then Vitest erkennt alle `tests/**/*.test.mjs`
+And jeder Test läuft mit identischem Ergebnis
+And die Test-Suite endet mit Exit-Code 0 und allen grünen Tests
+And Watch-Mode (`npm run test:watch`) funktioniert interaktiv
+```
+
+### Bereich 6: GitHub Actions CI-Matrix
+
+```gherkin
+Given ein PR gegen den `main`-Branch
+When GH-Actions der Test-Workflow läuft
+Then 3 Jobs laufen parallel: `windows-latest`, `macos-latest`, `ubuntu-latest`
+And jeder Job: Checkout mit `autocrlf: false`, Setup-Node 20, `npm ci`, `npm run lint`, `npm run typecheck`, `npm test`
+And alle drei müssen grün sein, damit Merge möglich ist (Branch-Protection)
+And bei Windows-Fehlern wird der fehlgeschlagene stderr im GH-Log sichtbar
+```
+
+### Bereich 7: CRLF-Resilienz
+
+```gherkin
+Given der User clont das Repo auf Windows mit Git `core.autocrlf=true` (Default)
+When Hooks versuchen, `CLAUDE.md` oder `wave-scope.json` zu parsen
+Then `.gitattributes` hat LF für alle Script-, Config- und JSON-Dateien erzwungen → Git behält LF bei Checkout
+And selbst wenn CRLF vorkommt: Node parst UTF-8 mit LF oder CRLF transparent (JSON.parse, fs.readFile mit string encoding)
+And keine `grep -q "^## Session Config"`-ähnlichen Anchor-Failures mehr
+```
+
+### Bereich 8: Upgrade-Pfad für bestehende User
+
+```gherkin
+Given ein User auf v2.0.0 aktualisiert auf v3.0.0
+When er die neue Version installiert
+Then README und CHANGELOG erklären den Breaking Change klar
+And ein explicit `npm install` im Plugin-Root ist die einzige zusätzliche Aktion
+And STATE.md, Session-History, Metrics-Files (JSONL) bleiben ohne Migration lesbar
+And Hooks-Verhalten ist funktional äquivalent zur alten Bash-Version
+```
+
+### Bereich 9: Fehlerpfade & Robustheit
+
+```gherkin
+Given `npm install` wurde noch nicht ausgeführt und `zx` fehlt in node_modules
+When ein Hook ausgelöst wird
+Then der Hook erkennt fehlende Dependencies, gibt eine verständliche Fehlermeldung auf stderr aus ("Run `npm install` in plugin root")
+And terminiert mit Exit-Code 0 statt 2 (non-blocking warn statt deny, damit die Session nicht komplett bricht)
+
+Given Node.js-Version < 20 ist installiert
+When ein Hook ausgeführt wird
+Then die erste `engines`-Check-Zeile gibt "Node 20+ required, found vX.Y.Z" aus und bricht sauber mit Exit-Code 1
+```
+
+### Bereich 10: Dokumentation ist aktuell und korrekt
+
+```gherkin
+Given ein neuer User liest README.md
+Then die Platform-Support-Tabelle listet Windows explizit als unterstützt (✅) mit Link zur Installation-Section
+And die Installation-Section beschreibt: (1) Node 20+ installieren, (2) Plugin klonen/installieren, (3) `npm install` im Plugin-Root, (4) Claude Code restart
+And CHANGELOG.md hat einen v3.0.0-Eintrag mit BREAKING-CHANGES-Section
+And `docs/migration-v3.md` existiert und beschreibt den Umstieg für Bestands-User
+```
+
+---
+
+## 4. Technical Notes
+
+### Affected Files
+
+**Neu (zu erstellen):**
+
+| Datei | Zweck |
+|---|---|
+| `package.json` | Plugin-Root: Node-deps, Scripts |
+| `.gitattributes` | LF für `.sh`/`.md`/JSON/YAML/`.mjs`, CRLF für `.ps1` |
+| `.github/workflows/test.yml` | CI-Matrix (win/mac/linux) |
+| `eslint.config.js` | ESLint v9 flat config |
+| `.prettierrc` | Prettier defaults |
+| `vitest.config.js` | Vitest config (environment `node`, pattern `tests/**/*.test.mjs`) |
+| `hooks/on-session-start.mjs` | ersetzt `.sh` |
+| `hooks/on-stop.mjs` | ersetzt `.sh` |
+| `hooks/enforce-scope.mjs` | ersetzt `.sh`, PoC aus Research liegt vor |
+| `hooks/enforce-commands.mjs` | ersetzt `.sh` |
+| `hooks/post-edit-validate.mjs` | ersetzt `.sh` |
+| `scripts/lib/platform.mjs` | ersetzt `platform.sh`, erweitert um OS-Detection |
+| `scripts/lib/path-utils.mjs` | Containment-Check, Relative-Resolve, Drive-Letter-Case |
+| `scripts/lib/config.mjs` | ersetzt `parse-config.sh` + `config-yaml-parser.sh` |
+| `scripts/lib/events.mjs` | ersetzt `events.sh` |
+| `scripts/lib/worktree.mjs` | ersetzt `worktree.sh` |
+| `scripts/lib/hardening.mjs` | ersetzt `hardening.sh` |
+| `scripts/lib/common.mjs` | ersetzt `common.sh` |
+| `tests/**/*.test.mjs` | Vitest-Suite (ersetzt `scripts/test/test-*.sh`) |
+| `docs/migration-v3.md` | Migration-Guide |
+
+**Zu modifizieren:**
+
+| Datei | Änderung |
+|---|---|
+| `hooks/hooks.json` | Alle `"command"`-Strings: `bash "$X.sh"` → `node "$X.mjs"` |
+| `README.md` | Platform-Support-Tabelle, Installation-Section, Troubleshooting |
+| `CHANGELOG.md` | v3.0.0 Entry mit BREAKING-CHANGES |
+| `CLAUDE.md` (plugin-repo) | Session Config + Developer-Setup-Notes |
+
+**Zu löschen (nach erfolgreichem Cutover):**
+
+| Datei | Grund |
+|---|---|
+| `hooks/*.sh` (5 Dateien) | Ersetzt durch `.mjs` |
+| `scripts/lib/*.sh` (7 Dateien) | Ersetzt durch `.mjs` |
+| `scripts/parse-config.sh` | Ersetzt durch `scripts/lib/config.mjs` |
+| `scripts/test/test-*.sh` (47 Dateien) | Ersetzt durch `tests/**/*.test.mjs` |
+| `scripts/test/run-all.sh` | Ersetzt durch `npm test` |
+
+### Architecture
+
+**Layering (nach Migration):**
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│ Claude Code Runtime (native: Mac/Win/Linux)                 │
+└────────────────────────┬────────────────────────────────────┘
+                         │ spawns via hooks.json
+                         ▼
+┌─────────────────────────────────────────────────────────────┐
+│ hooks/*.mjs (5 files, Node entry points)                    │
+│ — read stdin JSON, write stdout JSON, exit 0/2              │
+└────────────────────────┬────────────────────────────────────┘
+                         │ import
+                         ▼
+┌─────────────────────────────────────────────────────────────┐
+│ scripts/lib/*.mjs (shared libs)                             │
+│ — platform.mjs: OS + IDE detection                          │
+│ — path-utils.mjs: cross-platform path handling              │
+│ — config.mjs: CLAUDE.md / Session Config parser             │
+│ — events.mjs: JSONL event emission                          │
+│ — worktree.mjs: git worktree helpers                        │
+│ — hardening.mjs: env/runtime sanity checks                  │
+│ — common.mjs: shared utilities                              │
+└────────────────────────┬────────────────────────────────────┘
+                         │ uses
+                         ▼
+┌─────────────────────────────────────────────────────────────┐
+│ Node 20+ stdlib (path, fs/promises, os, url, child_process) │
+│ + zx ^8.1.0 (for template-literal shell ops where needed)   │
+└─────────────────────────────────────────────────────────────┘
+```
+
+**Key Patterns:**
+
+1. **Hook entry point pattern** (alle 5 Hooks):
+   ```javascript
+   #!/usr/bin/env node
+   import { readStdin, emitAllow, emitDeny, emitWarn } from './_lib/io.mjs';
+   
+   const input = await readStdin();  // JSON from Claude Code
+   // ... business logic ...
+   emitAllow();  // stdout JSON + exit 0
+   ```
+
+2. **Path-traversal-safe containment** (zentral in `path-utils.mjs`):
+   ```javascript
+   import path from 'path';
+   
+   export function isPathInside(child, parent) {
+     const relativePath = path.relative(path.resolve(parent), path.resolve(child));
+     return !relativePath.startsWith('..') && !path.isAbsolute(relativePath);
+   }
+   ```
+
+3. **Cross-platform tmpdir** (`common.mjs`):
+   ```javascript
+   import os from 'os';
+   import path from 'path';
+   
+   export function makeTmpPath(prefix) {
+     const rand = Math.random().toString(36).slice(2, 8);
+     return path.join(os.tmpdir(), `${prefix}-${Date.now()}-${rand}`);
+   }
+   ```
+
+4. **Graceful dep-check** (frontloaded in jedem Hook):
+   ```javascript
+   try {
+     await import('zx');
+   } catch {
+     console.error('session-orchestrator: Run `npm install` in plugin root first.');
+     process.exit(0);  // non-blocking
+   }
+   ```
+
+5. **zx-Nutzung** nur wo wir tatsächlich externe Commands shellen (git, glab, gh). Reine File-I/O + JSON-Parsing bleibt in Node-stdlib ohne zx.
+
+### Data Model Changes
+
+Keine. `.orchestrator/metrics/sessions.jsonl`, `wave-scope.json`, `STATE.md`, Session-Memory-Files bleiben im Format identisch. Nur das *wer-schreibt-sie* wechselt von Bash zu Node.
+
+### API Changes
+
+Keine externen APIs. `hooks/hooks.json` ist das einzige "öffentliche" Interface zu Claude Code — das ändert sich im *command*-Feld (`bash ...` → `node ...`) aber behält Struktur + Matcher + Event-Types bei.
+
+### Dependency Strategy
+
+- **Runtime:** `zx ^8.1.0` (Google, aktiv gewartet, battle-tested). Mit `^` pinned minor, damit Security-Patches automatisch.
+- **Dev:** `vitest ^2.0.0`, `eslint ^9.0.0` (flat config), `@eslint/js ^9.0.0`, `prettier ^3.0.0`.
+- **User-Install:** `npm install` im Plugin-Root. Keine globalen Abhängigkeiten. `node_modules/` in `.gitignore`.
+- **First-Run-Trigger:** Bootstrap-Gate (oder ein neuer SessionStart-Pre-Hook) checkt ob `node_modules/zx` existiert; wenn nicht, log-warnt und exit-0 (nicht blockierend).
+
+### Plattform-Detection-Erweiterung
+
+`scripts/lib/platform.mjs` exportiert zusätzlich zu den vorhandenen IDE-Feldern:
+
+```javascript
+export const SO_OS = process.platform;  // 'darwin' | 'linux' | 'win32'
+export const SO_IS_WINDOWS = SO_OS === 'win32';
+export const SO_IS_WSL = process.env.WSL_DISTRO_NAME !== undefined;
+export const SO_PATH_SEP = path.sep;
+```
+
+Downstream-Code kann verzweigen wo nötig (z.B. Drive-Letter-Normalization nur auf Windows).
+
+---
+
+## 5. Risks & Dependencies
+
+| Risk | Impact | Mitigation |
+|---|---|---|
+| **Claude-Code-Bug #32930**: Hook-Router ignoriert `shell`-Field, routet alles durch `/usr/bin/bash` auf Windows | Hoch: würde Node-Hooks blockieren, wenn es den `node`-Command auch betrifft | **Wir bypassen das**, weil unsere hooks.json `"command": "node ..."` nutzt (nicht `"shell": "powershell"`). Der Bug betrifft nur PowerShell-Shell-Hint, nicht direkten Node-Spawn. Verifizieren mit Windows-CI in Phase 1. |
+| **Breaking Change** für bestehende User | Mittel: v2→v3-User müssen `npm install` laufen lassen, sonst Hooks failen | Ausführlicher Migration-Guide, klare CHANGELOG-BREAKING-Section, README-Upgrade-Section. v3.0.0 als Major-Bump signalisiert Break offen. |
+| **`npm install`-Hürde** für Casual-User | Mittel: eine Aktion mehr als v2 | Im README als Einzeiler dokumentieren, SessionStart-Hook checkt und gibt freundliche Meldung wenn deps fehlen. |
+| **Windows-Contributors fehlen** für lokale Validierung während Entwicklung | Mittel: wir könnten Win-spezifische Bugs im Dev erst in CI sehen | `windows-latest`-CI ab Tag 1, nicht erst am Ende. Jeder PR muss Win-grün sein. |
+| **zx 8.x Breaking-Changes in zukünftigen Minor-Versions** | Gering: zx ist stabil seit v7 | `^8.1.0`-Pin, `package-lock.json` comitten, Monitoring der zx-Release-Notes. |
+| **GH-Actions-Cost: windows-latest ist 2× teurer** | Gering: PR-triggered only, keine Schedule-Runs | Pro-PR-Trigger reicht, keine Pushes auf Feature-Branches, `concurrency`-Gruppe um parallele Runs zu vermeiden. |
+| **Path-Traversal-Bug in enforce-scope.mjs** (Security!) | Hoch wenn, Breach für private Files | `path.relative`-basierter Containment-Check (nicht `startsWith`), Test-Case für `..`/`../..`-Szenarien mandatorisch, Code-Review durch security-reviewer-Agent im PR. |
+| **CRLF bei User-Checkouts vor `.gitattributes`-Commit** | Gering: nur beim allerersten Pull nach Commit | Docs-Hinweis: `git config core.autocrlf false` für neue Clones dieses Repos. |
+| **Startup-Cost Node-Hook vs Bash** (~180ms auf Windows) | Gering bei unserer Hook-Frequenz | Akzeptabel, weil Hooks ohnehin seltene Events sind (Session-Start, Tool-Use). Kein Hot-Path. |
+| **Skill-Prompts enthalten Bash-Beispiele, die ein LLM im User-Repo generieren könnte** | Gering: das LLM passt Code an Zielprojekt an | Out-of-Scope dieser Migration (siehe §2). Wenn sich LLM-Verhalten als Problem zeigt, separates Ticket. |
+| **Node 20 nicht installiert auf User-System** | Gering: Node 20 ist LTS seit Oct 2023, Claude-Code-Desktop bringt eigenes Node mit | `engines`-Check in package.json + Hook-intro-Check mit klarer Fehlermeldung. |
+| **Test-Framework-Migration bats → Vitest verliert Coverage** | Mittel: Behavioral-Tests müssen korrekt übersetzt werden | Jeder bats-Test wird 1:1 in Vitest übersetzt, nicht neu designed. Parallel-Testing (bats grün + Vitest grün) während Cutover. |
+
+### Dependencies
+
+| Dependency | Status | Relationship |
+|---|---|---|
+| **Claude Code v2.1.84+** | Released März 2026, aktuell | Required Baseline. Hook-JSON-Format stabil. |
+| **Node.js ≥ 20.0.0** | LTS seit Oct 2023 | Required Runtime. |
+| **Open Issue #86** (lifecycle-sim v6) | Offen, niedrige Priorität | Unabhängig; kann parallel gemerged werden. |
+| **GL#10 / Marketplace Anthropic-Review** | Closed, pending review | Nicht-blockierend. v3.0.0 würde nach Marketplace-Approval released. |
+| **obra/superpowers Skills** | Extern, stabil | Nutzen wir als Deps der Skills; Migration berührt sie nicht. |
+| **bootstrap.lock Schema** | v1 stabil | Unverändert. |
+| **`.orchestrator/metrics/sessions.jsonl` Format** | v2-stabil | Unverändert. |
+
+### Dokumentations-Anforderungen
+
+Vom User explizit gefordert: "dokumentiere alles sauber bitte und recherchiere unbedingt damit 100% das vorgehen klar ist".
+
+Ergebnis:
+- Dieser PRD (detailliert)
+- `docs/migration-v3.md` (User-Facing Migration-Guide)
+- `docs/plugin-architecture-v3.md` (Contributor-Facing: neue Layering, patterns, extension-points)
+- README-Update (Platform-Support + Installation)
+- CHANGELOG v3.0.0 mit BREAKING-CHANGES + Motivation + Migration-Summary
+- Pro Hook/Script-Migrations-Issue: Vor/Nach-Snippet in Issue-Body
+
+### Rollout-Strategie
+
+1. **Feature-Branch** `feat/windows-native-v3` (sauber separat).
+2. **CI ab Commit 1** auf allen drei OS; kein Merge ohne drei grüne Matrix-Jobs.
+3. **Hook-by-Hook-Migration** (pro Hook ein Commit/Issue, kleine diff-Surface, leicht review-bar).
+4. **Parallel-Period im Branch:** `.sh` bleibt bis alle `.mjs` grün sind; dann .sh in einem finalen Cleanup-Commit löschen.
+5. **Pre-Release** `v3.0.0-rc.1` → `v3.0.0-rc.2` nach Feedback → `v3.0.0` stable.
+6. **Marketplace-Update** nach Stable-Tag + README-Update.
+
+---
+
+<!-- Fin PRD -->

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,48 @@
+import js from "@eslint/js";
+
+export default [
+  js.configs.recommended,
+  {
+    languageOptions: {
+      ecmaVersion: 2024,
+      sourceType: "module",
+      globals: {
+        console: "readonly",
+        process: "readonly",
+        Buffer: "readonly",
+        __dirname: "readonly",
+        __filename: "readonly",
+        global: "readonly",
+        fetch: "readonly",
+        URL: "readonly",
+        URLSearchParams: "readonly",
+        setTimeout: "readonly",
+        clearTimeout: "readonly",
+        setInterval: "readonly",
+        clearInterval: "readonly",
+        setImmediate: "readonly",
+        clearImmediate: "readonly",
+      },
+    },
+    rules: {
+      "no-unused-vars": ["error", { argsIgnorePattern: "^_", varsIgnorePattern: "^_" }],
+      "no-undef": "error",
+      "prefer-const": "error",
+      "no-var": "error",
+      "eqeqeq": ["error", "always"],
+      "no-console": "off",
+    },
+    files: ["**/*.mjs", "**/*.js"],
+  },
+  {
+    ignores: [
+      "node_modules/**",
+      ".orchestrator/**",
+      ".claude/**",
+      ".codex/**",
+      ".cursor/**",
+      "docs/**",
+      "tests/**/*.fixture.*",
+    ],
+  },
+];

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,2500 @@
+{
+  "name": "session-orchestrator",
+  "version": "3.0.0-dev",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "session-orchestrator",
+      "version": "3.0.0-dev",
+      "license": "MIT",
+      "dependencies": {
+        "zx": "^8.1.0"
+      },
+      "devDependencies": {
+        "@eslint/js": "^9.0.0",
+        "eslint": "^9.0.0",
+        "prettier": "^3.0.0",
+        "vitest": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
+      "integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eslint-visitor-keys": "^3.4.3"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils/node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint-community/regexpp": {
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
+      "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@eslint/config-array": {
+      "version": "0.21.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.2.tgz",
+      "integrity": "sha512-nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/object-schema": "^2.1.7",
+        "debug": "^4.3.1",
+        "minimatch": "^3.1.5"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/config-helpers": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.4.2.tgz",
+      "integrity": "sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^0.17.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/core": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.17.0.tgz",
+      "integrity": "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/eslintrc": {
+      "version": "3.3.5",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.5.tgz",
+      "integrity": "sha512-4IlJx0X0qftVsN5E+/vGujTRIFtwuLbNsVUe7TO6zYPDR1O6nFwvwhIKEKSrl6dZchmYBITazxKoUYOjdtjlRg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^6.14.0",
+        "debug": "^4.3.2",
+        "espree": "^10.0.1",
+        "globals": "^14.0.0",
+        "ignore": "^5.2.0",
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^4.1.1",
+        "minimatch": "^3.1.5",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint/js": {
+      "version": "9.39.4",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.4.tgz",
+      "integrity": "sha512-nE7DEIchvtiFTwBw4Lfbu59PG+kCofhjsKaCWzxTpt4lfRjRMqG6uMBzKXuEcyXhOHoUp9riAm7/aWYGhXZ9cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      }
+    },
+    "node_modules/@eslint/object-schema": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.7.tgz",
+      "integrity": "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/plugin-kit": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.4.1.tgz",
+      "integrity": "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^0.17.0",
+        "levn": "^0.4.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@humanfs/core": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
+      "integrity": "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/types": "^0.15.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/node": {
+      "version": "0.16.8",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.8.tgz",
+      "integrity": "sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/core": "^0.19.2",
+        "@humanfs/types": "^0.15.0",
+        "@humanwhocodes/retry": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/types": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@humanfs/types/-/types-0.15.0.tgz",
+      "integrity": "sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanwhocodes/module-importer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.22"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@humanwhocodes/retry": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
+      "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.2.tgz",
+      "integrity": "sha512-dnlp69efPPg6Uaw2dVqzWRfAWRnYVb1XJ8CyyhIbZeaq4CA5/mLeZ1IEt9QqQxmbdvagjLIm2ZL8BxXv5lH4Yw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.2.tgz",
+      "integrity": "sha512-OqZTwDRDchGRHHm/hwLOL7uVPB9aUvI0am/eQuWMNyFHf5PSEQmyEeYYheA0EPPKUO/l0uigCp+iaTjoLjVoHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.2.tgz",
+      "integrity": "sha512-UwRE7CGpvSVEQS8gUMBe1uADWjNnVgP3Iusyda1nSRwNDCsRjnGc7w6El6WLQsXmZTbLZx9cecegumcitNfpmA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.2.tgz",
+      "integrity": "sha512-gjEtURKLCC5VXm1I+2i1u9OhxFsKAQJKTVB8WvDAHF+oZlq0GTVFOlTlO1q3AlCTE/DF32c16ESvfgqR7343/g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.2.tgz",
+      "integrity": "sha512-Bcl6CYDeAgE70cqZaMojOi/eK63h5Me97ZqAQoh77VPjMysA/4ORQBRGo3rRy45x4MzVlU9uZxs8Uwy7ZaKnBw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.2.tgz",
+      "integrity": "sha512-LU+TPda3mAE2QB0/Hp5VyeKJivpC6+tlOXd1VMoXV/YFMvk/MNk5iXeBfB4MQGRWyOYVJ01625vjkr0Az98OJQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.2.tgz",
+      "integrity": "sha512-2QxQrM+KQ7DAW4o22j+XZ6RKdxjLD7BOWTP0Bv0tmjdyhXSsr2Ul1oJDQqh9Zf5qOwTuTc7Ek83mOFaKnodPjg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.2.tgz",
+      "integrity": "sha512-TbziEu2DVsTEOPif2mKWkMeDMLoYjx95oESa9fkQQK7r/Orta0gnkcDpzwufEcAO2BLBsD7mZkXGFqEdMRRwfw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.2.tgz",
+      "integrity": "sha512-bO/rVDiDUuM2YfuCUwZ1t1cP+/yqjqz+Xf2VtkdppefuOFS2OSeAfgafaHNkFn0t02hEyXngZkxtGqXcXwO8Rg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.2.tgz",
+      "integrity": "sha512-hr26p7e93Rl0Za+JwW7EAnwAvKkehh12BU1Llm9Ykiibg4uIr2rbpxG9WCf56GuvidlTG9KiiQT/TXT1yAWxTA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.2.tgz",
+      "integrity": "sha512-pOjB/uSIyDt+ow3k/RcLvUAOGpysT2phDn7TTUB3n75SlIgZzM6NKAqlErPhoFU+npgY3/n+2HYIQVbF70P9/A==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.2.tgz",
+      "integrity": "sha512-2/w+q8jszv9Ww1c+6uJT3OwqhdmGP2/4T17cu8WuwyUuuaCDDJ2ojdyYwZzCxx0GcsZBhzi3HmH+J5pZNXnd+Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.2.tgz",
+      "integrity": "sha512-11+aL5vKheYgczxtPVVRhdptAM2H7fcDR5Gw4/bTcteuZBlH4oP9f5s9zYO9aGZvoGeBpqXI/9TZZihZ609wKw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.2.tgz",
+      "integrity": "sha512-i16fokAGK46IVZuV8LIIwMdtqhin9hfYkCh8pf8iC3QU3LpwL+1FSFGej+O7l3E/AoknL6Dclh2oTdnRMpTzFQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.2.tgz",
+      "integrity": "sha512-49FkKS6RGQoriDSK/6E2GkAsAuU5kETFCh7pG4yD/ylj9rKhTmO3elsnmBvRD4PgJPds5W2PkhC82aVwmUcJ7A==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.2.tgz",
+      "integrity": "sha512-mjYNkHPfGpUR00DuM1ZZIgs64Hpf4bWcz9Z41+4Q+pgDx73UwWdAYyf6EG/lRFldmdHHzgrYyge5akFUW0D3mQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.2.tgz",
+      "integrity": "sha512-ALyvJz965BQk8E9Al/JDKKDLH2kfKFLTGMlgkAbbYtZuJt9LU8DW3ZoDMCtQpXAltZxwBHevXz5u+gf0yA0YoA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.2.tgz",
+      "integrity": "sha512-UQjrkIdWrKI626Du8lCQ6MJp/6V1LAo2bOK9OTu4mSn8GGXIkPXk/Vsp4bLHCd9Z9Iz2OTEaokUE90VweJgIYQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.2.tgz",
+      "integrity": "sha512-bTsRGj6VlSdn/XD4CGyzMnzaBs9bsRxy79eTqTCBsA8TMIEky7qg48aPkvJvFe1HyzQ5oMZdg7AnVlWQSKLTnw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.2.tgz",
+      "integrity": "sha512-6d4Z3534xitaA1FcMWP7mQPq5zGwBmGbhphh2DwaA1aNIXUu3KTOfwrWpbwI4/Gr0uANo7NTtaykFyO2hPuFLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.2.tgz",
+      "integrity": "sha512-NetAg5iO2uN7eB8zE5qrZ3CSil+7IJt4WDFLcC75Ymywq1VZVD6qJ6EvNLjZ3rEm6gB7XW5JdT60c6MN35Z85Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.2.tgz",
+      "integrity": "sha512-NCYhOotpgWZ5kdxCZsv6Iudx0wX8980Q/oW4pNFNihpBKsDbEA1zpkfxJGC0yugsUuyDZ7gL37dbzwhR0VI7pQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.2.tgz",
+      "integrity": "sha512-RXsaOqXxfoUBQoOgvmmijVxJnW2IGB0eoMO7F8FAjaj0UTywUO/luSqimWBJn04WNgUkeNhh7fs7pESXajWmkg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.2.tgz",
+      "integrity": "sha512-qdAzEULD+/hzObedtmV6iBpdL5TIbKVztGiK7O3/KYSf+HIzU257+MX1EXJcyIiDbMAqmbwaufcYPvyRryeZtA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.2.tgz",
+      "integrity": "sha512-Nd/SgG27WoA9e+/TdK74KnHz852TLa94ovOYySo/yMPuTmpckK/jIF2jSwS3g7ELSKXK13/cVdmg1Z/DaCWKxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vitest/expect": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.9.tgz",
+      "integrity": "sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-2.1.9.tgz",
+      "integrity": "sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.12"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.9.tgz",
+      "integrity": "sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-2.1.9.tgz",
+      "integrity": "sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "2.1.9",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.1.9.tgz",
+      "integrity": "sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.1.9.tgz",
+      "integrity": "sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^3.0.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.1.9.tgz",
+      "integrity": "sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "loupe": "^3.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
+      "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
+      "license": "Python-2.0"
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/brace-expansion": {
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/deep-is": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint": {
+      "version": "9.39.4",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.4.tgz",
+      "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.8.0",
+        "@eslint-community/regexpp": "^4.12.1",
+        "@eslint/config-array": "^0.21.2",
+        "@eslint/config-helpers": "^0.4.2",
+        "@eslint/core": "^0.17.0",
+        "@eslint/eslintrc": "^3.3.5",
+        "@eslint/js": "9.39.4",
+        "@eslint/plugin-kit": "^0.4.1",
+        "@humanfs/node": "^0.16.6",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@humanwhocodes/retry": "^0.4.2",
+        "@types/estree": "^1.0.6",
+        "ajv": "^6.14.0",
+        "chalk": "^4.0.0",
+        "cross-spawn": "^7.0.6",
+        "debug": "^4.3.2",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^8.4.0",
+        "eslint-visitor-keys": "^4.2.1",
+        "espree": "^10.4.0",
+        "esquery": "^1.5.0",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^8.0.0",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "ignore": "^5.2.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "lodash.merge": "^4.6.2",
+        "minimatch": "^3.1.5",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.3"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "jiti": "*"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-scope": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
+      "integrity": "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-visitor-keys": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/espree": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
+      "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.15.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^4.2.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/esquery": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
+      "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "estraverse": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/file-entry-cache": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
+      "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flat-cache": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/flat-cache": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
+      "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flatted": "^3.2.9",
+        "keyv": "^4.5.4"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/flatted": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/globals": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
+      "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/import-fresh": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
+      "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.19"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/js-yaml": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/levn": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/optionator": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+      "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "callsites": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/postcss": {
+      "version": "8.5.10",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
+      "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
+      "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.2.tgz",
+      "integrity": "sha512-J9qZyW++QK/09NyN/zeO0dG/1GdGfyp9lV8ajHnRVLfo/uFsbji5mHnDgn/qYdUHyCkM2N+8VyspgZclfAh0eQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.60.2",
+        "@rollup/rollup-android-arm64": "4.60.2",
+        "@rollup/rollup-darwin-arm64": "4.60.2",
+        "@rollup/rollup-darwin-x64": "4.60.2",
+        "@rollup/rollup-freebsd-arm64": "4.60.2",
+        "@rollup/rollup-freebsd-x64": "4.60.2",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.2",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.2",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.2",
+        "@rollup/rollup-linux-arm64-musl": "4.60.2",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.2",
+        "@rollup/rollup-linux-loong64-musl": "4.60.2",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.2",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.2",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.2",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.2",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.2",
+        "@rollup/rollup-linux-x64-gnu": "4.60.2",
+        "@rollup/rollup-linux-x64-musl": "4.60.2",
+        "@rollup/rollup-openbsd-x64": "4.60.2",
+        "@rollup/rollup-openharmony-arm64": "4.60.2",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.2",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.2",
+        "@rollup/rollup-win32-x64-gnu": "4.60.2",
+        "@rollup/rollup-win32-x64-msvc": "4.60.2",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-1.2.0.tgz",
+      "integrity": "sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-3.0.2.tgz",
+      "integrity": "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/type-check": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/vite": {
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.1.9.tgz",
+      "integrity": "sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.3.7",
+        "es-module-lexer": "^1.5.4",
+        "pathe": "^1.1.2",
+        "vite": "^5.0.0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-2.1.9.tgz",
+      "integrity": "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "2.1.9",
+        "@vitest/mocker": "2.1.9",
+        "@vitest/pretty-format": "^2.1.9",
+        "@vitest/runner": "2.1.9",
+        "@vitest/snapshot": "2.1.9",
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "debug": "^4.3.7",
+        "expect-type": "^1.1.0",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2",
+        "std-env": "^3.8.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.1",
+        "tinypool": "^1.0.1",
+        "tinyrainbow": "^1.2.0",
+        "vite": "^5.0.0",
+        "vite-node": "2.1.9",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "@vitest/browser": "2.1.9",
+        "@vitest/ui": "2.1.9",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/word-wrap": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zx": {
+      "version": "8.8.5",
+      "resolved": "https://registry.npmjs.org/zx/-/zx-8.8.5.tgz",
+      "integrity": "sha512-SNgDF5L0gfN7FwVOdEFguY3orU5AkfFZm9B5YSHog/UDHv+lvmd82ZAsOenOkQixigwH2+yyH198AwNdKhj+RA==",
+      "license": "Apache-2.0",
+      "bin": {
+        "zx": "build/cli.js"
+      },
+      "engines": {
+        "node": ">= 12.17.0"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "session-orchestrator",
+  "version": "3.0.0-dev",
+  "description": "Session Orchestrator — Claude Code plugin for structured development sessions",
+  "type": "module",
+  "engines": { "node": ">=20.0.0" },
+  "scripts": {
+    "test": "vitest --run",
+    "test:watch": "vitest",
+    "lint": "eslint .",
+    "lint:fix": "eslint . --fix",
+    "typecheck": "node --check scripts/lib/*.mjs"
+  },
+  "dependencies": { "zx": "^8.1.0" },
+  "devDependencies": {
+    "@eslint/js": "^9.0.0",
+    "eslint": "^9.0.0",
+    "prettier": "^3.0.0",
+    "vitest": "^2.0.0"
+  },
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Kanevry/session-orchestrator.git"
+  }
+}

--- a/scripts/lib/config.mjs
+++ b/scripts/lib/config.mjs
@@ -1,0 +1,621 @@
+/**
+ * config.mjs — Session Config reader for CLAUDE.md / AGENTS.md.
+ *
+ * Produces behavior parity with scripts/parse-config.sh (plus its helper libs
+ * config-yaml-parser.sh and config-json-coercion.sh). Windows + CRLF safe.
+ *
+ * Part of v3.0.0 migration (Epic #124, issue #132).
+ */
+
+import { readFile, access } from 'node:fs/promises';
+import { join } from 'node:path';
+
+// ---------------------------------------------------------------------------
+// Internal: coercion helpers (ported from config-json-coercion.sh)
+// ---------------------------------------------------------------------------
+
+/**
+ * Look up a key in the parsed KV map; returns the raw string value or the
+ * given default. Last match wins (mirrors the shell `tail -1` behaviour).
+ * @param {Map<string, string>} kv
+ * @param {string} key
+ * @param {string|undefined} def
+ * @returns {string|undefined}
+ */
+function _getVal(kv, key, def) {
+  const val = kv.get(key);
+  if (val !== undefined) return val;
+  return def;
+}
+
+/**
+ * Coerce a value to a JSON string or null.
+ * @param {Map<string, string>} kv
+ * @param {string} key
+ * @param {string} [def] — omit for null default
+ * @returns {string|null}
+ */
+function _coerceString(kv, key, def) {
+  const val = _getVal(kv, key, def);
+  if (val === undefined || val === '' || val === 'none' || val === 'null') return null;
+  return val;
+}
+
+/**
+ * Coerce a value to an integer, supporting override syntax "N (k: M)".
+ * @param {Map<string, string>} kv
+ * @param {string} key
+ * @param {number} def
+ * @returns {number | {default: number, [k: string]: number}}
+ */
+function _coerceInteger(kv, key, def) {
+  const raw = _getVal(kv, key, String(def));
+
+  // Override syntax: "6 (deep: 18)" or "6 (deep: 18, fast: 4)"
+  const overrideMatch = raw.match(/^(\d+)\s*\(([^)]+)\)\s*$/);
+  if (overrideMatch) {
+    const base = parseInt(overrideMatch[1], 10);
+    if (isNaN(base)) throw new Error(`config.mjs: invalid integer base for '${key}': '${raw}'`);
+    const overridesStr = overrideMatch[2];
+    const result = { default: base };
+    for (const pair of overridesStr.split(',')) {
+      const colonIdx = pair.indexOf(':');
+      if (colonIdx === -1) continue;
+      const okey = pair.slice(0, colonIdx).trim();
+      const oval = pair.slice(colonIdx + 1).trim();
+      const oint = parseInt(oval, 10);
+      if (isNaN(oint) || !/^\d+$/.test(oval)) {
+        throw new Error(`config.mjs: invalid integer override for '${key}.${okey}': '${oval}'`);
+      }
+      result[okey] = oint;
+    }
+    return result;
+  }
+
+  if (!/^\d+$/.test(raw)) {
+    throw new Error(`config.mjs: invalid integer for '${key}': '${raw}'`);
+  }
+  return parseInt(raw, 10);
+}
+
+/**
+ * Coerce a value to a float with optional bounds.
+ * @param {Map<string, string>} kv
+ * @param {string} key
+ * @param {number} def
+ * @param {number} [min]
+ * @param {number} [max] — exclusive upper bound
+ * @returns {number}
+ */
+function _coerceFloat(kv, key, def, min, max) {
+  const raw = _getVal(kv, key, String(def));
+
+  if (!/^\d+(\.\d+)?$/.test(raw)) {
+    throw new Error(`config.mjs: invalid float for '${key}': '${raw}' (expected non-negative number)`);
+  }
+  const val = parseFloat(raw);
+
+  if (min !== undefined && val < min) {
+    throw new Error(`config.mjs: float '${key}' value '${raw}' is below minimum '${min}'`);
+  }
+  if (max !== undefined && val >= max) {
+    throw new Error(`config.mjs: float '${key}' value '${raw}' must be less than '${max}'`);
+  }
+  return val;
+}
+
+/**
+ * Coerce a value to a boolean.
+ * @param {Map<string, string>} kv
+ * @param {string} key
+ * @param {boolean} def
+ * @returns {boolean}
+ */
+function _coerceBoolean(kv, key, def) {
+  const raw = _getVal(kv, key, def ? 'true' : 'false');
+  const lower = raw.toLowerCase();
+  if (lower === 'true') return true;
+  if (lower === 'false') return false;
+  throw new Error(`config.mjs: invalid boolean for '${key}': '${raw}' (expected true or false)`);
+}
+
+/**
+ * Coerce a value to a JSON array of strings, or null.
+ * Handles "[a, b, c]", "a, b, c", "[]", "none", or absent (null).
+ * @param {Map<string, string>} kv
+ * @param {string} key
+ * @param {string|null} [def] — raw default string like "[all]" or "[]"
+ * @returns {string[]|null}
+ */
+function _coerceList(kv, key, def) {
+  const raw = _getVal(kv, key, def !== undefined ? def : undefined);
+
+  if (raw === undefined || raw === 'none' || raw === 'null') return null;
+
+  // Strip surrounding brackets
+  const stripped = raw.replace(/^\s*\[/, '').replace(/\]\s*$/, '').trim();
+
+  if (stripped === '') return [];
+
+  // If value contains '{', bail to null (complex object)
+  if (stripped.includes('{')) return null;
+
+  const items = stripped.split(',').map(s => s.trim()).filter(s => s.length > 0);
+  return items;
+}
+
+/**
+ * Coerce a value to an enum string (lower-cased), throw on invalid.
+ * @param {Map<string, string>} kv
+ * @param {string} key
+ * @param {string} def
+ * @param {string[]} allowed
+ * @returns {string}
+ */
+function _coerceEnum(kv, key, def, allowed) {
+  const raw = _getVal(kv, key, def);
+  const lower = raw.toLowerCase();
+  if (!allowed.includes(lower)) {
+    throw new Error(`config.mjs: ${key} must be ${allowed.join('|')}, got '${raw}'`);
+  }
+  return lower;
+}
+
+/**
+ * Coerce a value to a plain object of string values, or null.
+ * Handles "{ key1: val1, key2: val2 }".
+ * @param {Map<string, string>} kv
+ * @param {string} key
+ * @returns {Record<string,string>|null}
+ */
+function _coerceObject(kv, key) {
+  const raw = _getVal(kv, key, undefined);
+  if (raw === undefined || raw === 'none' || raw === 'null') return null;
+
+  const stripped = raw.replace(/^\s*\{/, '').replace(/\}\s*$/, '').trim();
+  if (stripped === '') return null;
+
+  const result = {};
+  for (const pair of stripped.split(',')) {
+    const colonIdx = pair.indexOf(':');
+    if (colonIdx === -1) continue;
+    const k = pair.slice(0, colonIdx).trim();
+    const v = pair.slice(colonIdx + 1).trim();
+    if (k && v) result[k] = v;
+  }
+  return Object.keys(result).length === 0 ? null : result;
+}
+
+/**
+ * Coerce a value to an object of boolean values (for enforcement-gates).
+ * @param {Map<string, string>} kv
+ * @param {string} key
+ * @returns {Record<string,boolean>|null}
+ */
+function _coerceBoolObject(kv, key) {
+  const raw = _getVal(kv, key, undefined);
+  if (raw === undefined || raw === 'none' || raw === 'null') return null;
+
+  const stripped = raw.replace(/^\s*\{/, '').replace(/\}\s*$/, '').trim();
+  if (stripped === '') return null;
+
+  const result = {};
+  for (const pair of stripped.split(',')) {
+    const colonIdx = pair.indexOf(':');
+    if (colonIdx === -1) continue;
+    const k = pair.slice(0, colonIdx).trim();
+    const v = pair.slice(colonIdx + 1).trim().toLowerCase();
+    if (!k) continue;
+    if (v === 'true') result[k] = true;
+    else if (v === 'false') result[k] = false;
+    else throw new Error(`config.mjs: invalid enforcement-gates value for '${k}': '${v}' (must be true or false)`);
+  }
+  return Object.keys(result).length === 0 ? null : result;
+}
+
+/**
+ * Coerce max-turns: positive integer or "auto".
+ * @param {Map<string, string>} kv
+ * @returns {number|string}
+ */
+function _coerceMaxTurns(kv) {
+  const raw = _getVal(kv, 'max-turns', 'auto');
+  const lower = raw.toLowerCase();
+  if (lower === 'auto') return 'auto';
+  if (/^\d+$/.test(raw)) {
+    const n = parseInt(raw, 10);
+    if (n <= 0) throw new Error(`config.mjs: invalid max-turns: '${raw}' (must be positive integer or 'auto')`);
+    return n;
+  }
+  throw new Error(`config.mjs: invalid max-turns: '${raw}' (must be positive integer or 'auto')`);
+}
+
+// ---------------------------------------------------------------------------
+// Internal: section extraction (ported from config-yaml-parser.sh)
+// ---------------------------------------------------------------------------
+
+/**
+ * Extract the raw ## Session Config block lines from markdown content.
+ * - CRLF-tolerant
+ * - Skips code fence lines (``` alone on a line)
+ * - Strips trailing whitespace from each line
+ * @param {string} content
+ * @returns {string[]} lines of the Session Config block
+ */
+function _extractConfigSection(content) {
+  const lines = content.split(/\r?\n/);
+  const result = [];
+  let inSection = false;
+
+  for (const rawLine of lines) {
+    const line = rawLine.replace(/\r$/, '');
+
+    if (line === '## Session Config') {
+      inSection = true;
+      continue;
+    }
+
+    if (inSection) {
+      // Next ## header closes the section
+      if (/^## /.test(line)) break;
+      // Skip standalone code fences
+      if (line.trim() === '```') continue;
+      // Strip trailing whitespace and collect
+      result.push(line.replace(/\s+$/, ''));
+    }
+  }
+
+  return result;
+}
+
+/**
+ * Parse the key-value pairs from extracted Session Config lines.
+ * Supports Format 1: `- **key:** value`
+ * Supports Format 2: plain `key: value`
+ * Last occurrence of a key wins.
+ * @param {string[]} lines
+ * @returns {Map<string, string>}
+ */
+function _parseKV(lines) {
+  // We accumulate all matches, last-match wins per key
+  const allPairs = [];
+
+  for (const line of lines) {
+    if (!line.trim()) continue;
+
+    let key = '';
+    let value = '';
+
+    // Format 1: - **key:** value
+    const fmt1 = line.match(/^\s*-\s+\*\*([^*:]+):\*\*\s*(.*)/);
+    if (fmt1) {
+      key = fmt1[1].trim();
+      value = fmt1[2].trim();
+    } else {
+      // Format 2: key: value (key starts with letter, rest alphanum/hyphen/underscore)
+      const fmt2 = line.match(/^\s*([a-zA-Z][a-zA-Z0-9_-]+):\s+(.*)/);
+      if (fmt2) {
+        key = fmt2[1].trim();
+        value = fmt2[2].trim();
+      } else {
+        continue;
+      }
+    }
+
+    if (!key) continue;
+
+    // Strip surrounding double quotes from value
+    if (value.startsWith('"') && value.endsWith('"') && value.length >= 2) {
+      value = value.slice(1, -1);
+    }
+
+    allPairs.push([key, value]);
+  }
+
+  // Last match wins: build the map by iterating in order
+  const kv = new Map();
+  for (const [k, v] of allPairs) {
+    kv.set(k, v);
+  }
+  return kv;
+}
+
+// ---------------------------------------------------------------------------
+// Internal: vault-sync block parser (ported from config-yaml-parser.sh)
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse the top-level `vault-sync:` YAML block from markdown content.
+ * The block can appear anywhere (inside or outside ## Session Config).
+ * Defaults: enabled=false, mode="warn", vault-dir=null, exclude=[].
+ * @param {string} content — full file contents
+ * @returns {{enabled: boolean, mode: string, "vault-dir": string|null, exclude: string[]}}
+ */
+function _parseVaultSync(content) {
+  const defaults = { enabled: false, mode: 'warn', 'vault-dir': null, exclude: [] };
+
+  const lines = content.split(/\r?\n/);
+  let inBlock = false;
+  const blockLines = [];
+
+  for (const rawLine of lines) {
+    const line = rawLine.replace(/\r$/, '');
+
+    if (!inBlock) {
+      // Detect `vault-sync:` at column 0 with optional trailing spaces
+      if (/^vault-sync:\s*$/.test(line)) {
+        inBlock = true;
+      }
+      continue;
+    }
+
+    // Block terminates at first non-indented (non-whitespace-leading) line
+    if (line.length > 0 && !/^\s/.test(line)) break;
+
+    blockLines.push(line);
+  }
+
+  if (blockLines.length === 0) return defaults;
+
+  let vsEnabled = false;
+  let vsMode = 'warn';
+  let vsDir = null;
+  const vsExclude = [];
+  let inExclude = false;
+
+  for (const rawLine of blockLines) {
+    // Strip inline comment and trailing whitespace, preserving leading indent
+    const clean = rawLine.replace(/\s*#.*$/, '').replace(/\s+$/, '');
+    if (!clean.trim()) continue;
+
+    // Dash-prefixed list item
+    if (/^\s+-\s+/.test(clean)) {
+      if (inExclude) {
+        let item = clean.replace(/^\s+-\s+/, '').trim();
+        // Strip surrounding quotes
+        if (item.startsWith('"') && item.endsWith('"')) item = item.slice(1, -1);
+        else if (item.startsWith("'") && item.endsWith("'")) item = item.slice(1, -1);
+        if (item) vsExclude.push(item);
+      }
+      continue;
+    }
+
+    // Any non-list line resets the exclude block state
+    inExclude = false;
+
+    // key: value under indentation
+    const kvMatch = clean.match(/^\s+([a-zA-Z_-]+):\s*(.*)/);
+    if (!kvMatch) continue;
+
+    const k = kvMatch[1];
+    let v = kvMatch[2].trim();
+    // Strip surrounding quotes
+    if (v.startsWith('"') && v.endsWith('"') && v.length >= 2) v = v.slice(1, -1);
+    else if (v.startsWith("'") && v.endsWith("'") && v.length >= 2) v = v.slice(1, -1);
+
+    switch (k) {
+      case 'enabled':
+        vsEnabled = v.toLowerCase() === 'true';
+        break;
+      case 'mode':
+        if (['hard', 'warn', 'off'].includes(v)) vsMode = v;
+        // invalid mode silently defaults to 'warn' (matches shell behaviour)
+        break;
+      case 'vault-dir':
+        if (v && v !== 'none' && v !== 'null') vsDir = v;
+        break;
+      case 'exclude':
+        if (!v) inExclude = true;
+        break;
+    }
+  }
+
+  return { enabled: vsEnabled, mode: vsMode, 'vault-dir': vsDir, exclude: vsExclude };
+}
+
+// ---------------------------------------------------------------------------
+// Internal: vault-integration sub-keys from Session Config KV map
+// ---------------------------------------------------------------------------
+
+/**
+ * Extract vault-integration sub-keys from the Session Config KV map.
+ * Sub-keys (enabled, vault-dir, mode) are stored flat in the same KV map
+ * because they appear as indented YAML inside the `vault-integration:` block
+ * but the shell parser treats them as top-level key-value pairs.
+ * @param {Map<string, string>} kv
+ * @returns {{enabled: boolean, "vault-dir": string|null, mode: string}}
+ */
+function _parseVaultIntegration(kv) {
+  const enabled = _coerceBoolean(kv, 'enabled', false);
+  const vaultDir = _coerceString(kv, 'vault-dir', undefined);
+  // mode enum: warn|strict|off (hard is legacy alias — shell only allows warn/strict/off)
+  const modeRaw = _getVal(kv, 'mode', 'warn');
+  const modeAllowed = ['warn', 'strict', 'off'];
+  const mode = modeAllowed.includes(modeRaw.toLowerCase()) ? modeRaw.toLowerCase() : 'warn';
+
+  return { enabled, 'vault-dir': vaultDir, mode };
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Read CLAUDE.md or AGENTS.md from the project root.
+ * Precedence: if AGENTS.md exists AND env var SO_PLATFORM === "codex", prefer AGENTS.md.
+ * Otherwise CLAUDE.md. Throws if neither file found.
+ * @param {string} projectRoot — absolute path to project root
+ * @returns {Promise<string>} file contents as string (CRLF-tolerant)
+ */
+export async function readConfigFile(projectRoot) {
+  const claudeMd = join(projectRoot, 'CLAUDE.md');
+  const agentsMd = join(projectRoot, 'AGENTS.md');
+
+  const isCodex = process.env.SO_PLATFORM === 'codex';
+
+  if (isCodex) {
+    // Prefer AGENTS.md for Codex platform
+    try {
+      await access(agentsMd);
+      return await readFile(agentsMd, 'utf8');
+    } catch {
+      // Fall through to CLAUDE.md
+    }
+  }
+
+  try {
+    await access(claudeMd);
+    return await readFile(claudeMd, 'utf8');
+  } catch {
+    // Try AGENTS.md as fallback (non-Codex)
+  }
+
+  try {
+    await access(agentsMd);
+    return await readFile(agentsMd, 'utf8');
+  } catch {
+    // Neither found
+  }
+
+  throw new Error(`config.mjs: neither CLAUDE.md nor AGENTS.md found in '${projectRoot}'`);
+}
+
+/**
+ * Parse ## Session Config block from markdown content.
+ * Applies all defaults for missing keys.
+ * @param {string} mdContent — full CLAUDE.md content
+ * @returns {object} config object with EXACT same shape as parse-config.sh stdout
+ * @throws if any enum value is invalid
+ */
+export function parseSessionConfig(mdContent) {
+  const sectionLines = _extractConfigSection(mdContent);
+  const kv = _parseKV(sectionLines);
+
+  // String fields
+  const vcs = _coerceString(kv, 'vcs', undefined);
+  const gitlabHost = _coerceString(kv, 'gitlab-host', undefined);
+  const mirror = _coerceString(kv, 'mirror', undefined);
+  const special = _coerceString(kv, 'special', undefined);
+  const pencil = _coerceString(kv, 'pencil', undefined);
+  const testCommand = _coerceString(kv, 'test-command', 'pnpm test --run');
+  const typecheckCommand = _coerceString(kv, 'typecheck-command', 'tsgo --noEmit');
+  const lintCommand = _coerceString(kv, 'lint-command', 'pnpm lint');
+  const baselineRef = _coerceString(kv, 'baseline-ref', undefined);
+  const baselineProjectId = _coerceString(kv, 'baseline-project-id', undefined);
+  const planBaselinePath = _coerceString(kv, 'plan-baseline-path', undefined);
+  const planDefaultVisibility = _coerceString(kv, 'plan-default-visibility', 'internal');
+  const planPrdLocation = _coerceString(kv, 'plan-prd-location', 'docs/prd/');
+  const planRetroLocation = _coerceString(kv, 'plan-retro-location', 'docs/retro/');
+
+  // Integer fields
+  const agentsPerWave = _coerceInteger(kv, 'agents-per-wave', 6);
+  const waves = _coerceInteger(kv, 'waves', 5);
+  const recentCommits = _coerceInteger(kv, 'recent-commits', 20);
+  const issueLimit = _coerceInteger(kv, 'issue-limit', 50);
+  const staleBranchDays = _coerceInteger(kv, 'stale-branch-days', 7);
+  const staleIssueDays = _coerceInteger(kv, 'stale-issue-days', 30);
+  const ssotFreshnessDays = _coerceInteger(kv, 'ssot-freshness-days', 5);
+  const pluginFreshnessDays = _coerceInteger(kv, 'plugin-freshness-days', 30);
+  const memoryCleanupThreshold = _coerceInteger(kv, 'memory-cleanup-threshold', 5);
+  const learningExpiryDays = _coerceInteger(kv, 'learning-expiry-days', 30);
+  const learningsSurfaceTopN = _coerceInteger(kv, 'learnings-surface-top-n', 15);
+  const groundingInjectionMaxFiles = _coerceInteger(kv, 'grounding-injection-max-files', 3);
+  const discoveryConfidenceThreshold = _coerceInteger(kv, 'discovery-confidence-threshold', 60);
+
+  // Float fields
+  const learningDecayRate = _coerceFloat(kv, 'learning-decay-rate', 0.05, 0.0, 1.0);
+
+  // Boolean fields
+  const persistence = _coerceBoolean(kv, 'persistence', true);
+  const ecosystemHealth = _coerceBoolean(kv, 'ecosystem-health', false);
+  const discoveryOnClose = _coerceBoolean(kv, 'discovery-on-close', false);
+  const reasoningOutput = _coerceBoolean(kv, 'reasoning-output', false);
+  const groundingCheck = _coerceBoolean(kv, 'grounding-check', true);
+
+  // List fields
+  const crossRepos = _coerceList(kv, 'cross-repos', undefined);
+  const ssotFiles = _coerceList(kv, 'ssot-files', undefined);
+  const discoveryProbes = _coerceList(kv, 'discovery-probes', '[all]');
+  const discoveryExcludePaths = _coerceList(kv, 'discovery-exclude-paths', '[]');
+  const healthEndpoints = _coerceList(kv, 'health-endpoints', undefined);
+
+  // Enum fields
+  const enforcement = _coerceEnum(kv, 'enforcement', 'warn', ['strict', 'warn', 'off']);
+  const isolation = _coerceEnum(kv, 'isolation', 'auto', ['worktree', 'none', 'auto']);
+  const discoverySeverityThreshold = _coerceEnum(kv, 'discovery-severity-threshold', 'low', ['critical', 'high', 'medium', 'low']);
+
+  // Object fields
+  const agentMapping = _coerceObject(kv, 'agent-mapping');
+  const enforcementGates = _coerceBoolObject(kv, 'enforcement-gates');
+
+  // Special field
+  const maxTurns = _coerceMaxTurns(kv);
+
+  // vault-integration sub-keys
+  const vaultIntegration = _parseVaultIntegration(kv);
+
+  // vault-sync: parsed from full content (can live outside Session Config)
+  const vaultSync = _parseVaultSync(mdContent);
+
+  return {
+    'agents-per-wave': agentsPerWave,
+    'waves': waves,
+    'recent-commits': recentCommits,
+    'special': special,
+    'vcs': vcs,
+    'gitlab-host': gitlabHost,
+    'mirror': mirror,
+    'cross-repos': crossRepos,
+    'pencil': pencil,
+    'ecosystem-health': ecosystemHealth,
+    'health-endpoints': healthEndpoints,
+    'issue-limit': issueLimit,
+    'stale-branch-days': staleBranchDays,
+    'stale-issue-days': staleIssueDays,
+    'test-command': testCommand,
+    'typecheck-command': typecheckCommand,
+    'lint-command': lintCommand,
+    'ssot-files': ssotFiles,
+    'ssot-freshness-days': ssotFreshnessDays,
+    'plugin-freshness-days': pluginFreshnessDays,
+    'discovery-on-close': discoveryOnClose,
+    'discovery-probes': discoveryProbes,
+    'discovery-exclude-paths': discoveryExcludePaths,
+    'discovery-severity-threshold': discoverySeverityThreshold,
+    'discovery-confidence-threshold': discoveryConfidenceThreshold,
+    'persistence': persistence,
+    'memory-cleanup-threshold': memoryCleanupThreshold,
+    'learning-expiry-days': learningExpiryDays,
+    'learnings-surface-top-n': learningsSurfaceTopN,
+    'learning-decay-rate': learningDecayRate,
+    'enforcement': enforcement,
+    'isolation': isolation,
+    'max-turns': maxTurns,
+    'baseline-ref': baselineRef,
+    'baseline-project-id': baselineProjectId,
+    'plan-baseline-path': planBaselinePath,
+    'plan-default-visibility': planDefaultVisibility,
+    'plan-prd-location': planPrdLocation,
+    'plan-retro-location': planRetroLocation,
+    'agent-mapping': agentMapping,
+    'enforcement-gates': enforcementGates,
+    'reasoning-output': reasoningOutput,
+    'grounding-injection-max-files': groundingInjectionMaxFiles,
+    'grounding-check': groundingCheck,
+    'vault-integration': vaultIntegration,
+    'vault-sync': vaultSync,
+  };
+}
+
+/**
+ * Lookup a config value, falling back to default.
+ * @param {object} config — result of parseSessionConfig
+ * @param {string} key — key name (e.g., "agents-per-wave")
+ * @param {*} defaultValue — fallback if key missing or null
+ * @returns {*} the config value or defaultValue
+ */
+export function getConfigValue(config, key, defaultValue = null) {
+  const val = config[key];
+  if (val === undefined || val === null) return defaultValue;
+  return val;
+}

--- a/scripts/lib/path-utils.mjs
+++ b/scripts/lib/path-utils.mjs
@@ -1,0 +1,134 @@
+/**
+ * path-utils.mjs — Path-traversal-safe helpers for cross-platform use.
+ *
+ * SECURITY-CRITICAL: Backs enforce-scope.mjs (CWE-23 protection).
+ *
+ * All functions are pure (no filesystem I/O). Callers must resolve symlinks
+ * explicitly if symlink semantics are relevant — this module does NOT follow
+ * symlinks to avoid TOCTOU vulnerabilities.
+ *
+ * Part of v3.0.0 migration (Epic #124, issue #130).
+ */
+
+import path from 'node:path';
+
+const IS_WINDOWS = process.platform === 'win32';
+
+/**
+ * Documented attack patterns covered by isPathInside.
+ * Exported for test self-check (Wave 4) and audit documentation.
+ */
+export const CWE_23_ATTACK_PATTERNS = [
+  'relative-escape',         // ../
+  'deep-relative-escape',    // ../../
+  'absolute-escape',         // /etc/passwd when parent is /home/user
+  'prefix-match-confusion',  // /home/userx vs /home/user (not a descendant)
+  'windows-drive-escape',    // C:\..\Windows
+  'case-mismatch',           // Windows Foo vs foo (locale-aware)
+  'cross-drive',             // C:\ vs D:\
+  'unc-path',                // \\server\share (Windows — unconditionally rejected)
+  'null-byte-injection',     // embedded \x00 (rejected via input guard)
+];
+
+function _assertNonEmptyString(value, fnName, argName) {
+  if (typeof value !== 'string' || value.length === 0) {
+    throw new TypeError(`${fnName}: ${argName} must be a non-empty string`);
+  }
+  if (value.includes('\x00')) {
+    throw new TypeError(`${fnName}: ${argName} must not contain null bytes`);
+  }
+}
+
+function _normalizeForCompare(p) {
+  // Locale-stable lowercasing on Windows to match filesystem case-insensitivity.
+  // toLocaleLowerCase('en-US') avoids Turkish-I style divergence from toLowerCase().
+  return IS_WINDOWS ? p.toLocaleLowerCase('en-US') : p;
+}
+
+/**
+ * Returns true if child is strictly inside parent (descendant, not equal).
+ *
+ * Rejects: relative/absolute escapes, UNC paths on Windows, null bytes, empty inputs.
+ * Case-insensitive on Windows (locale-stable).
+ *
+ * @param {string} child — path to test
+ * @param {string} parent — containing path
+ * @returns {boolean}
+ * @throws {TypeError} on invalid input (empty, null-byte, non-string)
+ */
+export function isPathInside(child, parent) {
+  _assertNonEmptyString(child, 'isPathInside', 'child');
+  _assertNonEmptyString(parent, 'isPathInside', 'parent');
+
+  // Unconditionally reject UNC paths on Windows as child input.
+  if (IS_WINDOWS && (child.startsWith('\\\\') || child.startsWith('//'))) {
+    return false;
+  }
+
+  const resolvedParent = path.resolve(parent);
+  const resolvedChild = path.resolve(child);
+  const pa = _normalizeForCompare(resolvedParent);
+  const ch = _normalizeForCompare(resolvedChild);
+  const rel = path.relative(pa, ch);
+
+  // Descendant iff: non-empty relative path, no leading '..', and not absolute.
+  return rel !== '' && !rel.startsWith('..') && !path.isAbsolute(rel);
+}
+
+/**
+ * Returns relative path from root to fullPath.
+ *
+ * Return contract:
+ *   - `'.'`        → fullPath IS root (same directory)
+ *   - `'<rel>'`    → fullPath is strictly inside root
+ *   - `null`       → fullPath is outside root
+ *
+ * Callers MUST distinguish `null` from `'.'` — do not use falsy checks.
+ *
+ * @param {string} root
+ * @param {string} fullPath
+ * @returns {string|null}
+ */
+export function relativeFromRoot(root, fullPath) {
+  _assertNonEmptyString(root, 'relativeFromRoot', 'root');
+  _assertNonEmptyString(fullPath, 'relativeFromRoot', 'fullPath');
+
+  const resolvedRoot = path.resolve(root);
+  const resolvedFull = path.resolve(fullPath);
+
+  if (_normalizeForCompare(resolvedRoot) === _normalizeForCompare(resolvedFull)) {
+    return '.';
+  }
+  if (!isPathInside(fullPath, root)) {
+    return null;
+  }
+  return path.relative(resolvedRoot, resolvedFull);
+}
+
+/**
+ * Lowercase on Windows (locale-stable), passthrough on POSIX.
+ *
+ * @param {string} p
+ * @returns {string}
+ */
+export function normalizeCase(p) {
+  _assertNonEmptyString(p, 'normalizeCase', 'p');
+  return _normalizeForCompare(p);
+}
+
+/**
+ * Returns true if two paths reside on the same drive.
+ * On POSIX, always returns true (single-root filesystem).
+ *
+ * @param {string} a
+ * @param {string} b
+ * @returns {boolean}
+ */
+export function sameDrive(a, b) {
+  _assertNonEmptyString(a, 'sameDrive', 'a');
+  _assertNonEmptyString(b, 'sameDrive', 'b');
+  if (!IS_WINDOWS) return true;
+  const rootA = path.parse(path.resolve(a)).root.toLowerCase();
+  const rootB = path.parse(path.resolve(b)).root.toLowerCase();
+  return rootA === rootB;
+}

--- a/scripts/lib/platform.mjs
+++ b/scripts/lib/platform.mjs
@@ -1,0 +1,263 @@
+/**
+ * platform.mjs — platform detection for session-orchestrator (Node.js port of platform.sh)
+ * ESM-importable. Uses only Node built-ins. No external dependencies.
+ *
+ * Exports 10 constants + 5 named helper functions:
+ *   SO_PLATFORM, SO_PLUGIN_ROOT, SO_PROJECT_DIR, SO_STATE_DIR, SO_CONFIG_FILE,
+ *   SO_SHARED_DIR, SO_OS, SO_IS_WINDOWS, SO_IS_WSL, SO_PATH_SEP
+ *   detectPlatform, resolvePluginRoot, resolveProjectDir, resolveStateDir, resolveConfigFile
+ */
+
+import { existsSync, statSync } from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { fileURLToPath } from 'node:url';
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+function _isFile(p) {
+  try { return statSync(p).isFile(); } catch { return false; }
+}
+
+function _isDir(p) {
+  try { return statSync(p).isDirectory(); } catch { return false; }
+}
+
+/**
+ * Walk up the directory tree from startDir looking for marker.
+ * Uses path.parse(dir).root so it terminates correctly on Windows ("C:\\")
+ * and POSIX ("/").
+ *
+ * @param {string} startDir   Absolute directory to begin walking from
+ * @param {string} marker     Relative sub-path to look for inside each candidate dir
+ * @param {'file'|'dir'|'any'} kind  What to check for existence
+ * @returns {string|null}  The directory that contains marker, or null
+ */
+function walkUpFor(startDir, marker, kind) {
+  let dir = path.resolve(startDir);
+  const root = path.parse(dir).root; // "/" on POSIX, "C:\\" on Windows
+
+  const check = (candidate) => {
+    if (!existsSync(candidate)) return false;
+    if (kind === 'file') return _isFile(candidate);
+    if (kind === 'dir')  return _isDir(candidate);
+    return true; // 'any'
+  };
+
+  while (dir !== root) {
+    if (check(path.join(dir, marker))) return dir;
+    const parent = path.dirname(dir);
+    if (parent === dir) break; // safety guard — should not happen but protects against edge cases
+    dir = parent;
+  }
+
+  // Check root itself
+  if (check(path.join(root, marker))) return root;
+
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// detectPlatform
+// ---------------------------------------------------------------------------
+
+/**
+ * Detect the host IDE/CLI platform.
+ *
+ * Detection order (mirrors platform.sh):
+ * 1. Env-var fast path: CLAUDE_PLUGIN_ROOT → "claude", CODEX_PLUGIN_ROOT → "codex",
+ *    CURSOR_RULES_DIR → "cursor"
+ * 2. Filesystem walk from CWD looking for marker dirs:
+ *    .claude-plugin → "claude", .codex-plugin → "codex", .cursor/rules → "cursor"
+ * 3. Default: "claude"
+ *
+ * @returns {"claude"|"codex"|"cursor"}
+ */
+export function detectPlatform() {
+  if (process.env.CLAUDE_PLUGIN_ROOT) return 'claude';
+  if (process.env.CODEX_PLUGIN_ROOT)  return 'codex';
+  if (process.env.CURSOR_RULES_DIR)   return 'cursor';
+
+  const cwd = process.cwd();
+
+  if (walkUpFor(cwd, '.claude-plugin',               'dir')) return 'claude';
+  if (walkUpFor(cwd, '.codex-plugin',                'dir')) return 'codex';
+  if (walkUpFor(cwd, path.join('.cursor', 'rules'),  'dir')) return 'cursor';
+
+  return 'claude';
+}
+
+// ---------------------------------------------------------------------------
+// resolvePluginRoot
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolve the absolute path to the session-orchestrator plugin directory.
+ *
+ * Detection order (mirrors platform.sh):
+ * 1. Platform-specific env var (CLAUDE_PLUGIN_ROOT / CODEX_PLUGIN_ROOT / CURSOR_RULES_DIR),
+ *    verified to be an existing directory
+ * 2. Walk up from this file's own directory looking for plugin.json (file) or skills/ (dir)
+ * 3. Known install-path fallbacks
+ *
+ * @param {"claude"|"codex"|"cursor"} [platform]
+ * @returns {string}  Absolute path, or empty string if nothing found
+ */
+export function resolvePluginRoot(platform) {
+  const plt = platform ?? detectPlatform();
+
+  // 1. Env-var fast path
+  if (plt === 'claude' && process.env.CLAUDE_PLUGIN_ROOT &&
+      _isDir(process.env.CLAUDE_PLUGIN_ROOT)) {
+    return process.env.CLAUDE_PLUGIN_ROOT;
+  }
+  if (plt === 'codex' && process.env.CODEX_PLUGIN_ROOT &&
+      _isDir(process.env.CODEX_PLUGIN_ROOT)) {
+    return process.env.CODEX_PLUGIN_ROOT;
+  }
+  if (plt === 'cursor' && process.env.CURSOR_RULES_DIR &&
+      _isDir(process.env.CURSOR_RULES_DIR)) {
+    return process.env.CURSOR_RULES_DIR;
+  }
+
+  // 2. Walk up from this module's own directory
+  const thisDir = path.dirname(fileURLToPath(import.meta.url));
+  const byPluginJson = walkUpFor(thisDir, 'plugin.json', 'file');
+  if (byPluginJson) return byPluginJson;
+  const bySkills = walkUpFor(thisDir, 'skills', 'dir');
+  if (bySkills) return bySkills;
+
+  // 3. Known install-path fallbacks
+  const home = os.homedir();
+  const fallbacks = [
+    path.join(home, '.claude',  'plugins', 'session-orchestrator'),
+    path.join(home, '.codex',   'plugins', 'session-orchestrator'),
+    path.join(home, 'Projects', 'session-orchestrator'),
+  ];
+  for (const fb of fallbacks) {
+    if (_isDir(fb)) return fb;
+  }
+
+  return '';
+}
+
+// ---------------------------------------------------------------------------
+// resolveProjectDir
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolve the absolute path to the current project root.
+ *
+ * Detection order (mirrors platform.sh):
+ * 1. CLAUDE_PROJECT_DIR → CODEX_PROJECT_DIR → CURSOR_PROJECT_DIR env vars
+ *    (CLAUDE wins when multiple are set — matches .sh order)
+ * 2. Walk CWD up looking for platform config file (CLAUDE.md / AGENTS.md) or .git
+ * 3. Default: process.cwd()
+ *
+ * @param {"claude"|"codex"|"cursor"} [platform]
+ * @returns {string}  Absolute path
+ */
+export function resolveProjectDir(platform) {
+  const plt = platform ?? detectPlatform();
+
+  // 1. Env-var fast path
+  if (process.env.CLAUDE_PROJECT_DIR)  return process.env.CLAUDE_PROJECT_DIR;
+  if (process.env.CODEX_PROJECT_DIR)   return process.env.CODEX_PROJECT_DIR;
+  if (process.env.CURSOR_PROJECT_DIR)  return process.env.CURSOR_PROJECT_DIR;
+
+  // 2. Walk up from CWD
+  const cwd = process.cwd();
+  const configFile = plt === 'codex' ? 'AGENTS.md' : 'CLAUDE.md';
+
+  const byConfig = walkUpFor(cwd, configFile, 'file');
+  if (byConfig) return byConfig;
+
+  const byGit = walkUpFor(cwd, '.git', 'any');
+  if (byGit) return byGit;
+
+  // 3. Default
+  return cwd;
+}
+
+// ---------------------------------------------------------------------------
+// resolveStateDir
+// ---------------------------------------------------------------------------
+
+/**
+ * Return the platform-native transient state directory name.
+ *
+ * | Platform | Result   |
+ * |----------|----------|
+ * | claude   | .claude  |
+ * | codex    | .codex   |
+ * | cursor   | .cursor  |
+ *
+ * @param {"claude"|"codex"|"cursor"} [platform]
+ * @returns {".claude"|".codex"|".cursor"}
+ */
+export function resolveStateDir(platform) {
+  const plt = platform ?? detectPlatform();
+  switch (plt) {
+    case 'codex':  return '.codex';
+    case 'cursor': return '.cursor';
+    default:       return '.claude';
+  }
+}
+
+// ---------------------------------------------------------------------------
+// resolveConfigFile
+// ---------------------------------------------------------------------------
+
+/**
+ * Return the platform config file name.
+ *
+ * | Platform | Result    |
+ * |----------|-----------|
+ * | codex    | AGENTS.md |
+ * | others   | CLAUDE.md |
+ *
+ * @param {"claude"|"codex"|"cursor"} [platform]
+ * @returns {"CLAUDE.md"|"AGENTS.md"}
+ */
+export function resolveConfigFile(platform) {
+  const plt = platform ?? detectPlatform();
+  return plt === 'codex' ? 'AGENTS.md' : 'CLAUDE.md';
+}
+
+// ---------------------------------------------------------------------------
+// Auto-initialise — compute all exported constants at module load
+// ---------------------------------------------------------------------------
+
+/** @type {"claude"|"codex"|"cursor"} */
+export const SO_PLATFORM = detectPlatform();
+
+/** Absolute path to the session-orchestrator plugin directory (empty string if unresolvable) */
+export const SO_PLUGIN_ROOT = resolvePluginRoot(SO_PLATFORM);
+
+/** Absolute path to the current project root */
+export const SO_PROJECT_DIR = resolveProjectDir(SO_PLATFORM);
+
+/** Platform-native state directory name */
+export const SO_STATE_DIR = resolveStateDir(SO_PLATFORM);
+
+/** Platform config file name */
+export const SO_CONFIG_FILE = resolveConfigFile(SO_PLATFORM);
+
+/** Shared orchestrator directory name — always ".orchestrator" */
+export const SO_SHARED_DIR = '.orchestrator';
+
+// --- v3 OS / Windows exports ---
+
+/** Current OS identifier: process.platform ("darwin" | "linux" | "win32" | ...) */
+export const SO_OS = process.platform;
+
+/** True when running on Windows (native) */
+export const SO_IS_WINDOWS = process.platform === 'win32';
+
+/** True when running inside WSL (Windows Subsystem for Linux) */
+export const SO_IS_WSL = process.env.WSL_DISTRO_NAME !== undefined;
+
+/** Native path segment separator ("/" on POSIX, "\\" on Windows) */
+export const SO_PATH_SEP = path.sep;

--- a/scripts/vault-mirror.mjs
+++ b/scripts/vault-mirror.mjs
@@ -116,7 +116,7 @@ function truncateAtWord(str, maxLen) {
 
 /** Determine if a YAML title value needs quoting (contains : # or starts with -). */
 function yamlQuoteIfNeeded(value) {
-  if (/[:#{}\[\],&*?|<>=!%@`]/.test(value) || value.startsWith('-') || value.startsWith('"')) {
+  if (/[:#{}[\],&*?|<>=!%@`]/.test(value) || value.startsWith('-') || value.startsWith('"')) {
     return `"${value.replace(/"/g, '\\"')}"`;
   }
   return value;
@@ -149,12 +149,12 @@ function parseFrontmatter(content) {
 function generateLearningNote(entry, slug) {
   const REQUIRED_LEARNING_FIELDS = ['id', 'type', 'subject', 'insight', 'evidence', 'confidence', 'source_session', 'created_at'];
   for (const field of REQUIRED_LEARNING_FIELDS) {
-    if (entry[field] == null) {
+    if (entry[field] === null || entry[field] === undefined) {
       throw new Error(`vault-mirror: learning entry missing required field '${field}' (id=${entry.id ?? '<no id>'})`);
     }
   }
 
-  const { id, type, subject, insight, evidence, confidence, source_session, created_at, expires_at } = entry;
+  const { id: _id, type, subject: _subject, insight, evidence, confidence, source_session, created_at, expires_at } = entry;
 
   const status = confidence > 0.8 ? 'verified' : 'draft';
   const created = toDate(created_at);
@@ -199,7 +199,7 @@ ${evidence}
 function generateSessionNote(entry) {
   const REQUIRED_SESSION_FIELDS = ['session_id', 'session_type', 'started_at', 'completed_at', 'total_waves', 'total_agents', 'total_files_changed', 'agent_summary', 'waves', 'effectiveness'];
   for (const field of REQUIRED_SESSION_FIELDS) {
-    if (entry[field] == null) {
+    if (entry[field] === null || entry[field] === undefined) {
       throw new Error(`vault-mirror: session entry missing required field '${field}' (session_id=${entry.session_id ?? '<no session_id>'})`);
     }
   }
@@ -293,7 +293,7 @@ function emitAction(action, filePath, fileKind, id) {
 
 // ── Core processing ───────────────────────────────────────────────────────────
 
-async function processLearning(entry, lineNum) {
+async function processLearning(entry, _lineNum) {
   const { id: entryId, subject, created_at } = entry;
 
   // Derive slug
@@ -374,7 +374,7 @@ async function processLearning(entry, lineNum) {
   emitAction('created', targetPath, kind, slug);
 }
 
-async function processSession(entry, lineNum) {
+async function processSession(entry, _lineNum) {
   const { session_id: rawSessionId } = entry;
 
   // Validate session_id as a filesystem-safe slug; fall back to a uuid-derived slug if not

--- a/skills/_shared/state-ownership.md
+++ b/skills/_shared/state-ownership.md
@@ -32,7 +32,7 @@ total-waves: <N>
 |-------|--------|------------|
 | **wave-executor** | Read + Write (owner) | Creates STATE.md (Pre-Wave 1b), updates after each wave (current-wave, Wave History, Deviations) |
 | **session-end** | Read + Status-only write | Reads for metrics extraction (Phase 1.7), sets `status: completed` (Phase 3.4). Exception: only field modified is `status` in frontmatter. |
-| **session-start** | Read-only | Reads for continuity checks (Phase 0.5): inspects `status` field to detect crashed/paused sessions |
+| **session-start** | Read + conditional reset | Reads for continuity checks (Phase 1.5): inspects `status` field to detect crashed/paused sessions. May reset STATE.md to idle at the boundary between a completed session and a new session — only when prior `status: completed`. The reset clears `current-wave` (→ 0), sets `status: idle`, demotes `## Wave History` into `## Previous Session`, and empties `## Deviations`. Never resets on `active` or `paused` (those paths are user-interactive). |
 | **evolve** | Read-only | Reads `## Deviations` section for deviation pattern extraction (Step 2.2, pattern 5) |
 
 ## Guards

--- a/skills/session-start/SKILL.md
+++ b/skills/session-start/SKILL.md
@@ -46,8 +46,22 @@ Before reading STATE.md contents, validate the branch field:
 1. **STATE.md exists** — read it and inspect the `status` field:
    - `status: active` — previous session crashed or was interrupted. Use the AskUserQuestion tool to present: "Found unfinished session from [started_at]. [N] waves completed. Resume or start fresh?" with options to resume the previous plan or start a new session.
    - `status: paused` — session was intentionally paused. Use AskUserQuestion to offer resuming from the pause point or starting fresh.
-   - `status: completed` — previous session ended cleanly. Note the summary for context (what was done, what was deferred) but continue with normal initialization.
+   - `status: completed` — previous session ended cleanly. Note the summary for context (what was done, what was deferred), then **reset STATE.md to idle** before any new session state is written (see "Idle Reset" below). Continue with normal initialization.
 2. **STATE.md does not exist** — first session or persistence was previously off. Continue normally.
+
+### Idle Reset (completed-branch only)
+
+When (and only when) the prior `status` is `completed`, rewrite STATE.md to a clean idle state before Phase 1b (Initialize STATE.md) runs. This prevents the next agent from reading a stale "completed" banner at session-start, while preserving the prior session's record in a demoted archive block.
+
+Reset rules — applies ONLY on the `completed` branch. Do NOT perform this reset on `active` or `paused`; those paths stay user-interactive via AskUserQuestion.
+
+1. Set frontmatter `status: idle`.
+2. Clear `current-wave` (set to `0`).
+3. Move the existing `## Wave History` body into a new `## Previous Session` archive section (retain the record, but demote it below the new session's live state). Remove the original `## Wave History` section — wave-executor will recreate it on the next wave.
+4. Clear `## Deviations` (leave the heading with an empty body so the schema is preserved).
+5. Leave other frontmatter fields (`schema-version`, `session-type`, `branch`, `issues`, `started_at`, `total-waves`) intact until Phase 1b overwrites them with the new session's values.
+
+Rationale: `/close` intentionally keeps STATE.md as a record so the next session-start can read it. This reset completes that contract by demoting the record before new session state is written, so a fresh session never appears "already completed".
 
 Also read `<state-dir>/STATUS.md` if it exists for additional project-level context.
 

--- a/skills/vault-sync/validator.mjs
+++ b/skills/vault-sync/validator.mjs
@@ -23,7 +23,6 @@
 
 import { readdirSync, readFileSync, statSync, existsSync } from 'node:fs';
 import { join, relative, resolve, dirname, basename } from 'node:path';
-import { fileURLToPath } from 'node:url';
 import { z } from 'zod';
 import YAML from 'yaml';
 
@@ -127,7 +126,7 @@ for (let i = 0; i < args.length; i++) {
 // Operates on POSIX-style forward-slash relative paths.
 function globToRegExp(glob) {
   // Normalise input
-  let g = glob.replace(/\\/g, '/');
+  const g = glob.replace(/\\/g, '/');
   let re = '^';
   for (let i = 0; i < g.length; i++) {
     const c = g[i];

--- a/tests/fixtures/config-crlf.md
+++ b/tests/fixtures/config-crlf.md
@@ -1,0 +1,5 @@
+# Project
+
+## Session Config
+
+persistence: true

--- a/tests/fixtures/config-full.md
+++ b/tests/fixtures/config-full.md
@@ -1,0 +1,12 @@
+# Test Project
+
+## Session Config
+
+persistence: true
+enforcement: warn
+recent-commits: 20
+test-command: for f in scripts/test/test-*.sh; do bash "$f" || exit 1; done
+typecheck-command: false
+lint-command: false
+stale-branch-days: 7
+plugin-freshness-days: 30

--- a/tests/fixtures/config-invalid-enum.md
+++ b/tests/fixtures/config-invalid-enum.md
@@ -1,0 +1,3 @@
+## Session Config
+
+enforcement: loose

--- a/tests/fixtures/config-minimal.md
+++ b/tests/fixtures/config-minimal.md
@@ -1,0 +1,5 @@
+# Project
+
+## Session Config
+
+persistence: true

--- a/tests/fixtures/config-no-block.md
+++ b/tests/fixtures/config-no-block.md
@@ -1,0 +1,7 @@
+# Project
+
+No Session Config block here.
+
+## Other Section
+
+This is not a config.

--- a/tests/lib/config.test.mjs
+++ b/tests/lib/config.test.mjs
@@ -1,0 +1,484 @@
+/**
+ * config.test.mjs — Vitest tests for scripts/lib/config.mjs
+ *
+ * Covers:
+ *  - parseSessionConfig: minimal, defaults, full, CRLF, no-block, invalid enum,
+ *    integer override syntax, vault-integration nested object
+ *  - getConfigValue: existing key, missing key
+ *  - readConfigFile: finds CLAUDE.md, throws when neither file exists
+ *  - Parity: parseSessionConfig result matches bash scripts/parse-config.sh JSON output
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync, mkdtempSync } from 'node:fs';
+import { spawnSync } from 'node:child_process';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { readConfigFile, parseSessionConfig, getConfigValue } from '../../scripts/lib/config.mjs';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const WORKTREE_ROOT = new URL('../../', import.meta.url).pathname;
+const FIXTURES = new URL('../fixtures/', import.meta.url).pathname;
+
+function readFixture(name) {
+  return readFileSync(join(FIXTURES, name), 'utf8');
+}
+
+// ---------------------------------------------------------------------------
+// parseSessionConfig
+// ---------------------------------------------------------------------------
+
+describe('parseSessionConfig', () => {
+  describe('minimal config', () => {
+    it('returns persistence: true from explicit value', () => {
+      const config = parseSessionConfig(readFixture('config-minimal.md'));
+      expect(config.persistence).toBe(true);
+    });
+
+    it('applies default agents-per-wave of 6', () => {
+      const config = parseSessionConfig(readFixture('config-minimal.md'));
+      expect(config['agents-per-wave']).toBe(6);
+    });
+
+    it('applies default waves of 5', () => {
+      const config = parseSessionConfig(readFixture('config-minimal.md'));
+      expect(config.waves).toBe(5);
+    });
+
+    it('applies default enforcement of warn', () => {
+      const config = parseSessionConfig(readFixture('config-minimal.md'));
+      expect(config.enforcement).toBe('warn');
+    });
+
+    it('applies default isolation of auto', () => {
+      const config = parseSessionConfig(readFixture('config-minimal.md'));
+      expect(config.isolation).toBe('auto');
+    });
+
+    it('applies default test-command to pnpm test --run', () => {
+      const config = parseSessionConfig(readFixture('config-minimal.md'));
+      expect(config['test-command']).toBe('pnpm test --run');
+    });
+
+    it('applies default typecheck-command to tsgo --noEmit', () => {
+      const config = parseSessionConfig(readFixture('config-minimal.md'));
+      expect(config['typecheck-command']).toBe('tsgo --noEmit');
+    });
+
+    it('applies default lint-command to pnpm lint', () => {
+      const config = parseSessionConfig(readFixture('config-minimal.md'));
+      expect(config['lint-command']).toBe('pnpm lint');
+    });
+
+    it('applies default recent-commits of 20', () => {
+      const config = parseSessionConfig(readFixture('config-minimal.md'));
+      expect(config['recent-commits']).toBe(20);
+    });
+
+    it('applies null to optional string fields not present', () => {
+      const config = parseSessionConfig(readFixture('config-minimal.md'));
+      expect(config.vcs).toBeNull();
+      expect(config['gitlab-host']).toBeNull();
+      expect(config.mirror).toBeNull();
+      expect(config['cross-repos']).toBeNull();
+    });
+
+    it('returns all expected top-level keys', () => {
+      const config = parseSessionConfig(readFixture('config-minimal.md'));
+      const expectedKeys = [
+        'agents-per-wave', 'waves', 'recent-commits', 'special', 'vcs',
+        'gitlab-host', 'mirror', 'cross-repos', 'pencil', 'ecosystem-health',
+        'health-endpoints', 'issue-limit', 'stale-branch-days', 'stale-issue-days',
+        'test-command', 'typecheck-command', 'lint-command', 'ssot-files',
+        'ssot-freshness-days', 'plugin-freshness-days', 'discovery-on-close',
+        'discovery-probes', 'discovery-exclude-paths', 'discovery-severity-threshold',
+        'discovery-confidence-threshold', 'persistence', 'memory-cleanup-threshold',
+        'learning-expiry-days', 'learnings-surface-top-n', 'learning-decay-rate',
+        'enforcement', 'isolation', 'max-turns', 'baseline-ref', 'baseline-project-id',
+        'plan-baseline-path', 'plan-default-visibility', 'plan-prd-location',
+        'plan-retro-location', 'agent-mapping', 'enforcement-gates', 'reasoning-output',
+        'grounding-injection-max-files', 'grounding-check', 'vault-integration', 'vault-sync',
+      ];
+      for (const key of expectedKeys) {
+        expect(config, `expected key '${key}' to be present`).toHaveProperty(key);
+      }
+    });
+  });
+
+  describe('default values', () => {
+    it('defaults discovery-probes to [all]', () => {
+      const config = parseSessionConfig(readFixture('config-minimal.md'));
+      expect(config['discovery-probes']).toEqual(['all']);
+    });
+
+    it('defaults discovery-exclude-paths to []', () => {
+      const config = parseSessionConfig(readFixture('config-minimal.md'));
+      expect(config['discovery-exclude-paths']).toEqual([]);
+    });
+
+    it('defaults max-turns to auto', () => {
+      const config = parseSessionConfig(readFixture('config-minimal.md'));
+      expect(config['max-turns']).toBe('auto');
+    });
+
+    it('defaults learning-decay-rate to 0.05', () => {
+      const config = parseSessionConfig(readFixture('config-minimal.md'));
+      expect(config['learning-decay-rate']).toBe(0.05);
+    });
+
+    it('defaults ecosystem-health to false', () => {
+      const config = parseSessionConfig(readFixture('config-minimal.md'));
+      expect(config['ecosystem-health']).toBe(false);
+    });
+
+    it('defaults issue-limit to 50', () => {
+      const config = parseSessionConfig(readFixture('config-minimal.md'));
+      expect(config['issue-limit']).toBe(50);
+    });
+
+    it('defaults plan-default-visibility to internal', () => {
+      const config = parseSessionConfig(readFixture('config-minimal.md'));
+      expect(config['plan-default-visibility']).toBe('internal');
+    });
+
+    it('defaults plan-prd-location to docs/prd/', () => {
+      const config = parseSessionConfig(readFixture('config-minimal.md'));
+      expect(config['plan-prd-location']).toBe('docs/prd/');
+    });
+
+    it('defaults plan-retro-location to docs/retro/', () => {
+      const config = parseSessionConfig(readFixture('config-minimal.md'));
+      expect(config['plan-retro-location']).toBe('docs/retro/');
+    });
+
+    it('defaults grounding-check to true', () => {
+      const config = parseSessionConfig(readFixture('config-minimal.md'));
+      expect(config['grounding-check']).toBe(true);
+    });
+  });
+
+  describe('full config (CLAUDE.md fixture)', () => {
+    it('parses test-command verbatim with embedded quotes', () => {
+      const config = parseSessionConfig(readFixture('config-full.md'));
+      expect(config['test-command']).toBe(
+        'for f in scripts/test/test-*.sh; do bash "$f" || exit 1; done'
+      );
+    });
+
+    it('parses typecheck-command: false as string "false"', () => {
+      const config = parseSessionConfig(readFixture('config-full.md'));
+      // "false" is the string value from the config (not filtered to null)
+      // parse-config.sh treats it as a string via json_string which returns "false"
+      expect(config['typecheck-command']).toBe('false');
+    });
+
+    it('parses lint-command: false as string "false"', () => {
+      const config = parseSessionConfig(readFixture('config-full.md'));
+      expect(config['lint-command']).toBe('false');
+    });
+
+    it('parses stale-branch-days: 7', () => {
+      const config = parseSessionConfig(readFixture('config-full.md'));
+      expect(config['stale-branch-days']).toBe(7);
+    });
+
+    it('parses plugin-freshness-days: 30', () => {
+      const config = parseSessionConfig(readFixture('config-full.md'));
+      expect(config['plugin-freshness-days']).toBe(30);
+    });
+
+    it('parses recent-commits: 20', () => {
+      const config = parseSessionConfig(readFixture('config-full.md'));
+      expect(config['recent-commits']).toBe(20);
+    });
+
+    it('parses enforcement: warn', () => {
+      const config = parseSessionConfig(readFixture('config-full.md'));
+      expect(config.enforcement).toBe('warn');
+    });
+  });
+
+  describe('parity with parse-config.sh', () => {
+    it.skipIf(process.platform === 'win32')(
+      'produces JSON matching bash parse-config.sh output on CLAUDE.md (sorted keys)',
+      () => {
+        const claudeMdPath = join(WORKTREE_ROOT, 'CLAUDE.md');
+        const claudeMdContent = readFileSync(claudeMdPath, 'utf8');
+
+        // Run bash parse-config.sh
+        const result = spawnSync(
+          'bash',
+          [join(WORKTREE_ROOT, 'scripts/parse-config.sh'), claudeMdPath],
+          { encoding: 'utf8', timeout: 10000 }
+        );
+
+        if (result.error) {
+          throw result.error;
+        }
+        if (result.status !== 0) {
+          throw new Error(`parse-config.sh failed (exit ${result.status}): ${result.stderr}`);
+        }
+
+        const bashJson = JSON.parse(result.stdout);
+        const mjsConfig = parseSessionConfig(claudeMdContent);
+
+        // Compare with sorted keys for deterministic diff output
+        const sortedKeys = Object.keys(bashJson).sort();
+        const bashSorted = JSON.stringify(bashJson, sortedKeys);
+        const mjsSorted = JSON.stringify(mjsConfig, sortedKeys);
+
+        if (bashSorted !== mjsSorted) {
+          // Find mismatched keys for a useful failure message
+          const diffs = [];
+          for (const k of sortedKeys) {
+            const bashVal = JSON.stringify(bashJson[k]);
+            const mjsVal = JSON.stringify(mjsConfig[k]);
+            if (bashVal !== mjsVal) {
+              diffs.push(`  "${k}": bash=${bashVal} | mjs=${mjsVal}`);
+            }
+          }
+          throw new Error(
+            `config.mjs diverged from parse-config.sh:\n${diffs.join('\n')}`
+          );
+        }
+
+        expect(bashSorted).toBe(mjsSorted);
+      }
+    );
+  });
+
+  describe('CRLF-tolerant', () => {
+    it('raw fixture bytes contain \\r\\n', () => {
+      const raw = readFileSync(join(FIXTURES, 'config-crlf.md'));
+      expect(raw.includes(Buffer.from('\r\n'))).toBe(true);
+    });
+
+    it('produces same persistence value as LF version', () => {
+      const crlfContent = readFileSync(join(FIXTURES, 'config-crlf.md'), 'utf8');
+      const lfContent = readFixture('config-minimal.md');
+      const crlfConfig = parseSessionConfig(crlfContent);
+      const lfConfig = parseSessionConfig(lfContent);
+      expect(crlfConfig.persistence).toBe(lfConfig.persistence);
+      expect(crlfConfig.persistence).toBe(true);
+    });
+
+    it('produces same agents-per-wave default as LF version', () => {
+      const crlfContent = readFileSync(join(FIXTURES, 'config-crlf.md'), 'utf8');
+      const lfContent = readFixture('config-minimal.md');
+      const crlfConfig = parseSessionConfig(crlfContent);
+      const lfConfig = parseSessionConfig(lfContent);
+      expect(crlfConfig['agents-per-wave']).toBe(lfConfig['agents-per-wave']);
+      expect(crlfConfig['agents-per-wave']).toBe(6);
+    });
+
+    it('produces same enforcement default as LF version', () => {
+      const crlfContent = readFileSync(join(FIXTURES, 'config-crlf.md'), 'utf8');
+      const lfContent = readFixture('config-minimal.md');
+      const crlfConfig = parseSessionConfig(crlfContent);
+      const lfConfig = parseSessionConfig(lfContent);
+      expect(crlfConfig.enforcement).toBe(lfConfig.enforcement);
+      expect(crlfConfig.enforcement).toBe('warn');
+    });
+  });
+
+  describe('no Session Config block', () => {
+    it('does not throw', () => {
+      expect(() => parseSessionConfig(readFixture('config-no-block.md'))).not.toThrow();
+    });
+
+    it('returns agents-per-wave default of 6', () => {
+      const config = parseSessionConfig(readFixture('config-no-block.md'));
+      expect(config['agents-per-wave']).toBe(6);
+    });
+
+    it('returns enforcement default of warn', () => {
+      const config = parseSessionConfig(readFixture('config-no-block.md'));
+      expect(config.enforcement).toBe('warn');
+    });
+
+    it('returns persistence default of true', () => {
+      const config = parseSessionConfig(readFixture('config-no-block.md'));
+      expect(config.persistence).toBe(true);
+    });
+
+    it('returns max-turns default of auto', () => {
+      const config = parseSessionConfig(readFixture('config-no-block.md'));
+      expect(config['max-turns']).toBe('auto');
+    });
+  });
+
+  describe('invalid enum throws', () => {
+    it('throws for enforcement: loose', () => {
+      expect(() => parseSessionConfig(readFixture('config-invalid-enum.md'))).toThrow();
+    });
+
+    it('error message mentions "enforcement"', () => {
+      expect(() => parseSessionConfig(readFixture('config-invalid-enum.md'))).toThrow(
+        /enforcement/
+      );
+    });
+
+    it('error message mentions allowed values', () => {
+      expect(() => parseSessionConfig(readFixture('config-invalid-enum.md'))).toThrow(
+        /strict|warn|off/
+      );
+    });
+  });
+
+  describe('integer override syntax', () => {
+    it('parses agents-per-wave: 6 (deep: 18) into object with default and deep', () => {
+      const content = `## Session Config\n\nagents-per-wave: 6 (deep: 18)\n`;
+      const config = parseSessionConfig(content);
+      expect(config['agents-per-wave']).toEqual({ default: 6, deep: 18 });
+    });
+
+    it('sets default property to 6', () => {
+      const content = `## Session Config\n\nagents-per-wave: 6 (deep: 18)\n`;
+      const config = parseSessionConfig(content);
+      expect(config['agents-per-wave'].default).toBe(6);
+    });
+
+    it('sets deep property to 18', () => {
+      const content = `## Session Config\n\nagents-per-wave: 6 (deep: 18)\n`;
+      const config = parseSessionConfig(content);
+      expect(config['agents-per-wave'].deep).toBe(18);
+    });
+
+    it('parses multiple overrides in one field', () => {
+      const content = `## Session Config\n\nwaves: 5 (deep: 10, fast: 3)\n`;
+      const config = parseSessionConfig(content);
+      expect(config.waves).toEqual({ default: 5, deep: 10, fast: 3 });
+    });
+  });
+
+  describe('vault-integration nested object', () => {
+    it('returns vault-integration with enabled, vault-dir, mode keys when absent', () => {
+      const config = parseSessionConfig(readFixture('config-minimal.md'));
+      expect(config['vault-integration']).toHaveProperty('enabled');
+      expect(config['vault-integration']).toHaveProperty('vault-dir');
+      expect(config['vault-integration']).toHaveProperty('mode');
+    });
+
+    it('defaults vault-integration.enabled to false', () => {
+      const config = parseSessionConfig(readFixture('config-minimal.md'));
+      expect(config['vault-integration'].enabled).toBe(false);
+    });
+
+    it('defaults vault-integration.vault-dir to null', () => {
+      const config = parseSessionConfig(readFixture('config-minimal.md'));
+      expect(config['vault-integration']['vault-dir']).toBeNull();
+    });
+
+    it('defaults vault-integration.mode to warn', () => {
+      const config = parseSessionConfig(readFixture('config-minimal.md'));
+      expect(config['vault-integration'].mode).toBe('warn');
+    });
+
+    it('parses explicit vault-integration sub-keys from Session Config', () => {
+      const content = [
+        '## Session Config',
+        '',
+        'enabled: true',
+        'vault-dir: /secrets/vault',
+        'mode: strict',
+      ].join('\n');
+      const config = parseSessionConfig(content);
+      expect(config['vault-integration'].enabled).toBe(true);
+      expect(config['vault-integration']['vault-dir']).toBe('/secrets/vault');
+      expect(config['vault-integration'].mode).toBe('strict');
+    });
+
+    it('defaults vault-sync to disabled with empty exclude list', () => {
+      const config = parseSessionConfig(readFixture('config-minimal.md'));
+      expect(config['vault-sync'].enabled).toBe(false);
+      expect(config['vault-sync'].exclude).toEqual([]);
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getConfigValue
+// ---------------------------------------------------------------------------
+
+describe('getConfigValue', () => {
+  it('returns the config value for an existing key', () => {
+    const config = parseSessionConfig(readFixture('config-minimal.md'));
+    const result = getConfigValue(config, 'agents-per-wave', 99);
+    expect(result).toBe(6);
+  });
+
+  it('ignores the defaultValue when key exists', () => {
+    const config = parseSessionConfig(readFixture('config-minimal.md'));
+    // enforcement is 'warn', not the defaultValue we pass
+    const result = getConfigValue(config, 'enforcement', 'strict');
+    expect(result).toBe('warn');
+  });
+
+  it('returns defaultValue for a missing key', () => {
+    const config = {};
+    const result = getConfigValue(config, 'nonexistent-key', 'fallback');
+    expect(result).toBe('fallback');
+  });
+
+  it('returns defaultValue when key value is null', () => {
+    const config = parseSessionConfig(readFixture('config-minimal.md'));
+    // vcs is null in minimal config
+    const result = getConfigValue(config, 'vcs', 'default-vcs');
+    expect(result).toBe('default-vcs');
+  });
+
+  it('returns null as defaultValue when no defaultValue given and key is missing', () => {
+    const result = getConfigValue({}, 'missing');
+    expect(result).toBeNull();
+  });
+
+  it('returns boolean true correctly', () => {
+    const config = parseSessionConfig(readFixture('config-minimal.md'));
+    const result = getConfigValue(config, 'persistence', false);
+    expect(result).toBe(true);
+  });
+
+  it('returns array values correctly', () => {
+    const config = parseSessionConfig(readFixture('config-minimal.md'));
+    const result = getConfigValue(config, 'discovery-probes', null);
+    expect(result).toEqual(['all']);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// readConfigFile
+// ---------------------------------------------------------------------------
+
+describe('readConfigFile', () => {
+  it('finds and returns CLAUDE.md content from the project root', async () => {
+    const content = await readConfigFile(WORKTREE_ROOT);
+    expect(typeof content).toBe('string');
+    expect(content.length).toBeGreaterThan(0);
+  });
+
+  it('returned content contains ## Session Config header', async () => {
+    const content = await readConfigFile(WORKTREE_ROOT);
+    expect(content).toContain('## Session Config');
+  });
+
+  it('returned content is parseable by parseSessionConfig', async () => {
+    const content = await readConfigFile(WORKTREE_ROOT);
+    const config = parseSessionConfig(content);
+    // Must produce a valid object with key fields
+    expect(config['agents-per-wave']).toBe(6);
+    expect(config.enforcement).toBe('warn');
+  });
+
+  it('throws when neither CLAUDE.md nor AGENTS.md exists in the given directory', async () => {
+    const tmpDir = mkdtempSync(join(tmpdir(), 'config-test-'));
+    await expect(readConfigFile(tmpDir)).rejects.toThrow(/CLAUDE\.md|AGENTS\.md/);
+  });
+
+  it('error from missing files mentions the projectRoot path', async () => {
+    const tmpDir = mkdtempSync(join(tmpdir(), 'config-test-'));
+    await expect(readConfigFile(tmpDir)).rejects.toThrow(tmpDir);
+  });
+});

--- a/tests/lib/path-utils.test.mjs
+++ b/tests/lib/path-utils.test.mjs
@@ -1,0 +1,322 @@
+/**
+ * tests/lib/path-utils.test.mjs
+ *
+ * Security-critical tests for path-utils.mjs (CWE-23 path traversal prevention).
+ * Covers all attack patterns documented in CWE_23_ATTACK_PATTERNS.
+ *
+ * Issue #130 — Wave 4 (Quality) of v3.0.0 migration.
+ */
+
+import { describe, it, expect } from 'vitest';
+import path from 'node:path';
+import {
+  isPathInside,
+  relativeFromRoot,
+  normalizeCase,
+  sameDrive,
+  CWE_23_ATTACK_PATTERNS,
+} from '../../scripts/lib/path-utils.mjs';
+
+// ── isPathInside — positive (descendant returns true) ─────────────────────────
+
+describe('isPathInside — positive: descendant returns true', () => {
+  it('direct child returns true', () => {
+    expect(isPathInside('/home/user/foo', '/home/user')).toBe(true);
+  });
+
+  it('deeply nested descendant returns true', () => {
+    expect(isPathInside('/a/b/c/d/e', '/a/b')).toBe(true);
+  });
+
+  it('single-level child of root-level parent returns true', () => {
+    expect(isPathInside('/home/user/docs/file.txt', '/home/user/docs')).toBe(true);
+  });
+});
+
+// ── isPathInside — boundary (exact same path) ─────────────────────────────────
+
+describe('isPathInside — boundary: same path is not a descendant', () => {
+  it('exact same path returns false', () => {
+    expect(isPathInside('/home/user', '/home/user')).toBe(false);
+  });
+});
+
+// ── isPathInside — CWE-23 rejections ─────────────────────────────────────────
+
+describe('isPathInside — CWE-23: path traversal attacks return false', () => {
+  it('relative escape via .. returns false (CWE-23: relative-escape)', () => {
+    // /home/user/../other resolves to /home/other — outside /home/user
+    expect(isPathInside('/home/user/../other', '/home/user')).toBe(false);
+  });
+
+  it('deeper relative escape via multiple .. returns false (CWE-23: relative-escape)', () => {
+    // /home/user/a/../../b resolves to /home/b — outside /home/user
+    expect(isPathInside('/home/user/a/../../b', '/home/user')).toBe(false);
+  });
+
+  it('absolute path outside parent returns false (CWE-23: absolute-escape)', () => {
+    // /etc/passwd is completely outside /home/user
+    expect(isPathInside('/etc/passwd', '/home/user')).toBe(false);
+  });
+
+  it('prefix-match that is not a descendant returns false (CWE-23: prefix-match-confusion)', () => {
+    // /home/userx/foo must NOT be treated as inside /home/user
+    // because 'user' is a prefix of 'userx' but not a directory boundary
+    expect(isPathInside('/home/userx/foo', '/home/user')).toBe(false);
+  });
+
+  it('parent directory itself is not inside itself (boundary integrity)', () => {
+    // Edge case: the parent of /home/user is /home — /home/user is not inside /home/user
+    expect(isPathInside('/home', '/home/user')).toBe(false);
+  });
+
+  it('sibling directory returns false (CWE-23: absolute-escape)', () => {
+    expect(isPathInside('/home/attacker', '/home/user')).toBe(false);
+  });
+});
+
+// ── isPathInside — input validation ──────────────────────────────────────────
+
+describe('isPathInside — input validation: throws TypeError on bad input', () => {
+  it('empty string child throws TypeError with "non-empty" in message', () => {
+    expect(() => isPathInside('', '/home')).toThrowError(/non-empty/);
+  });
+
+  it('empty string parent throws TypeError with "non-empty" in message', () => {
+    expect(() => isPathInside('/foo', '')).toThrowError(/non-empty/);
+  });
+
+  it('null byte in child path throws TypeError with "null byte" in message', () => {
+    expect(() => isPathInside('/a\x00', '/home')).toThrowError(/null byte/);
+  });
+
+  it('null byte in parent path throws TypeError with "null byte" in message', () => {
+    expect(() => isPathInside('/a/b', '/home\x00')).toThrowError(/null byte/);
+  });
+
+  it('null child throws TypeError', () => {
+    expect(() => isPathInside(null, '/home')).toThrow(TypeError);
+  });
+
+  it('undefined child throws TypeError', () => {
+    expect(() => isPathInside(undefined, '/home')).toThrow(TypeError);
+  });
+
+  it('numeric child throws TypeError', () => {
+    expect(() => isPathInside(42, '/home')).toThrow(TypeError);
+  });
+
+  it('object child throws TypeError', () => {
+    expect(() => isPathInside({}, '/home')).toThrow(TypeError);
+  });
+
+  it('null parent throws TypeError', () => {
+    expect(() => isPathInside('/foo', null)).toThrow(TypeError);
+  });
+});
+
+// ── isPathInside — Windows-specific (conditional on process.platform) ─────────
+
+describe('isPathInside — Windows-specific tests', () => {
+  it.skipIf(process.platform !== 'win32')(
+    'UNC path child rejected when parent is a local drive (CWE-23: unc-path)',
+    () => {
+      // \\server\share\foo is a UNC path; C:\Users is a local drive path
+      // They are in different namespaces — should never be considered "inside" each other
+      expect(isPathInside('\\\\server\\share\\foo', 'C:\\Users')).toBe(false);
+    },
+  );
+
+  it.skipIf(process.platform !== 'win32')(
+    'cross-drive path returns false (D: is not inside C:)',
+    () => {
+      expect(isPathInside('D:\\Users\\foo', 'C:\\Users')).toBe(false);
+    },
+  );
+
+  it.skipIf(process.platform !== 'win32')(
+    'same drive descendant returns true on Windows',
+    () => {
+      expect(isPathInside('C:\\Users\\dev\\project\\src', 'C:\\Users\\dev\\project')).toBe(true);
+    },
+  );
+
+  it.skipIf(process.platform !== 'win32')(
+    'Windows drive letter case difference does not affect result (CWE-23: drive-case)',
+    () => {
+      // c: vs C: should be treated as the same drive
+      expect(isPathInside('C:\\Users\\dev\\file.txt', 'c:\\Users\\dev')).toBe(true);
+    },
+  );
+});
+
+// ── relativeFromRoot ──────────────────────────────────────────────────────────
+
+describe('relativeFromRoot — basic behaviour', () => {
+  it('same path returns "." (dot, not empty string)', () => {
+    expect(relativeFromRoot('/home/user', '/home/user')).toBe('.');
+  });
+
+  it('descendant returns relative path using platform separator', () => {
+    const result = relativeFromRoot('/home/user', '/home/user/foo/bar');
+    // On POSIX: 'foo/bar', on Windows (if tested with POSIX paths): may vary
+    // Normalise by joining with platform sep to make the assertion cross-platform
+    expect(result).toBe(['foo', 'bar'].join(path.sep));
+  });
+
+  it('path outside root returns null', () => {
+    expect(relativeFromRoot('/home/user', '/etc')).toBeNull();
+  });
+
+  it('parent directory of root returns null', () => {
+    expect(relativeFromRoot('/home/user', '/home')).toBeNull();
+  });
+
+  it('sibling directory returns null', () => {
+    expect(relativeFromRoot('/home/user', '/home/other')).toBeNull();
+  });
+
+  it('"." is distinct from null — same-path is truthy, outside is null', () => {
+    const same = relativeFromRoot('/x', '/x');
+    const outside = relativeFromRoot('/x', '/y');
+    expect(same).toBe('.');
+    expect(outside).toBeNull();
+    // Verify the distinction matters: '.' is truthy, null is falsy
+    expect(same).toBeTruthy();
+    expect(outside).toBeNull();
+  });
+
+  it('immediate child returns its basename only', () => {
+    expect(relativeFromRoot('/home/user', '/home/user/readme.txt')).toBe('readme.txt');
+  });
+});
+
+// ── normalizeCase ─────────────────────────────────────────────────────────────
+
+describe('normalizeCase — platform behaviour', () => {
+  it('on non-Windows: returns path unchanged (passthrough)', () => {
+    // This assertion is only correct on non-Windows; on Windows it would be lowercased.
+    // We test the POSIX behaviour explicitly.
+    if (process.platform !== 'win32') {
+      expect(normalizeCase('Foo/Bar')).toBe('Foo/Bar');
+    }
+  });
+
+  it('on non-Windows: mixed case is preserved', () => {
+    if (process.platform !== 'win32') {
+      expect(normalizeCase('/Home/User/SomeFile.txt')).toBe('/Home/User/SomeFile.txt');
+    }
+  });
+
+  it.skipIf(process.platform !== 'win32')(
+    'on Windows: lowercases the entire path',
+    () => {
+      expect(normalizeCase('C:\\Users\\FOO')).toBe('c:\\users\\foo');
+    },
+  );
+
+  it.skipIf(process.platform !== 'win32')(
+    'on Windows: drive letter is lowercased',
+    () => {
+      expect(normalizeCase('C:\\path')).toBe('c:\\path');
+    },
+  );
+});
+
+// ── sameDrive ─────────────────────────────────────────────────────────────────
+
+describe('sameDrive — platform behaviour', () => {
+  it('on POSIX: always returns true (no drive letters)', () => {
+    if (process.platform !== 'win32') {
+      expect(sameDrive('/a', '/b')).toBe(true);
+      expect(sameDrive('/home/user', '/etc/passwd')).toBe(true);
+      expect(sameDrive('/', '/very/deep/path')).toBe(true);
+    }
+  });
+
+  it.skipIf(process.platform !== 'win32')(
+    'on Windows: same drive returns true',
+    () => {
+      expect(sameDrive('C:\\Users\\foo', 'C:\\Windows')).toBe(true);
+    },
+  );
+
+  it.skipIf(process.platform !== 'win32')(
+    'on Windows: different drives return false (CWE-23: cross-drive)',
+    () => {
+      expect(sameDrive('C:\\a', 'D:\\a')).toBe(false);
+    },
+  );
+
+  it.skipIf(process.platform !== 'win32')(
+    'on Windows: drive letter case difference is normalised (C: == c:)',
+    () => {
+      expect(sameDrive('C:\\path', 'c:\\other')).toBe(true);
+    },
+  );
+});
+
+// ── CWE_23_ATTACK_PATTERNS ────────────────────────────────────────────────────
+
+describe('CWE_23_ATTACK_PATTERNS — taxonomy completeness', () => {
+  it('is an array', () => {
+    expect(Array.isArray(CWE_23_ATTACK_PATTERNS)).toBe(true);
+  });
+
+  it('contains "relative-escape"', () => {
+    expect(CWE_23_ATTACK_PATTERNS).toContain('relative-escape');
+  });
+
+  it('contains "absolute-escape"', () => {
+    expect(CWE_23_ATTACK_PATTERNS).toContain('absolute-escape');
+  });
+
+  it('contains "null-byte-injection"', () => {
+    expect(CWE_23_ATTACK_PATTERNS).toContain('null-byte-injection');
+  });
+
+  it('contains "unc-path"', () => {
+    expect(CWE_23_ATTACK_PATTERNS).toContain('unc-path');
+  });
+
+  it('contains "prefix-match-confusion"', () => {
+    expect(CWE_23_ATTACK_PATTERNS).toContain('prefix-match-confusion');
+  });
+
+  it('has at least 5 documented patterns (security-critical module must be thorough)', () => {
+    expect(CWE_23_ATTACK_PATTERNS.length).toBeGreaterThanOrEqual(5);
+  });
+
+  it('all entries are non-empty strings', () => {
+    for (const pattern of CWE_23_ATTACK_PATTERNS) {
+      expect(typeof pattern).toBe('string');
+      expect(pattern.length).toBeGreaterThan(0);
+    }
+  });
+});
+
+// ── Integration: isPathInside + relativeFromRoot agree ────────────────────────
+
+describe('integration: isPathInside and relativeFromRoot are consistent', () => {
+  it('when isPathInside is true, relativeFromRoot returns non-null non-dot', () => {
+    const child = '/home/user/project/src/index.js';
+    const parent = '/home/user/project';
+    expect(isPathInside(child, parent)).toBe(true);
+    const rel = relativeFromRoot(parent, child);
+    expect(rel).not.toBeNull();
+    expect(rel).not.toBe('.');
+  });
+
+  it('when isPathInside is false (sibling), relativeFromRoot returns null', () => {
+    const sibling = '/home/other';
+    const parent = '/home/user';
+    expect(isPathInside(sibling, parent)).toBe(false);
+    expect(relativeFromRoot(parent, sibling)).toBeNull();
+  });
+
+  it('when paths are equal, isPathInside is false and relativeFromRoot returns "."', () => {
+    const p = '/home/user';
+    expect(isPathInside(p, p)).toBe(false);
+    expect(relativeFromRoot(p, p)).toBe('.');
+  });
+});

--- a/tests/lib/platform.test.mjs
+++ b/tests/lib/platform.test.mjs
@@ -1,0 +1,300 @@
+/**
+ * tests/lib/platform.test.mjs
+ *
+ * Unit tests for scripts/lib/platform.mjs
+ * Runs on Ubuntu, macOS, and Windows via CI matrix.
+ */
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+  SO_OS,
+  SO_IS_WINDOWS,
+  SO_IS_WSL,
+  SO_PATH_SEP,
+  SO_PLATFORM,
+  SO_PLUGIN_ROOT,
+  SO_PROJECT_DIR,
+  SO_STATE_DIR,
+  SO_CONFIG_FILE,
+  SO_SHARED_DIR,
+  detectPlatform,
+  resolvePluginRoot,
+  resolveProjectDir,
+  resolveStateDir,
+  resolveConfigFile,
+} from '../../scripts/lib/platform.mjs';
+
+// ---------------------------------------------------------------------------
+// 1. Module loads without error — all exports are defined
+// ---------------------------------------------------------------------------
+
+describe('module exports', () => {
+  it('exports all 10 constants as non-undefined values', () => {
+    expect(SO_OS).not.toBeUndefined();
+    expect(SO_IS_WINDOWS).not.toBeUndefined();
+    expect(SO_IS_WSL).not.toBeUndefined();
+    expect(SO_PATH_SEP).not.toBeUndefined();
+    expect(SO_PLATFORM).not.toBeUndefined();
+    expect(SO_PLUGIN_ROOT).not.toBeUndefined();
+    expect(SO_PROJECT_DIR).not.toBeUndefined();
+    expect(SO_STATE_DIR).not.toBeUndefined();
+    expect(SO_CONFIG_FILE).not.toBeUndefined();
+    expect(SO_SHARED_DIR).not.toBeUndefined();
+  });
+
+  it('exports all 5 functions as callable functions', () => {
+    expect(typeof detectPlatform).toBe('function');
+    expect(typeof resolvePluginRoot).toBe('function');
+    expect(typeof resolveProjectDir).toBe('function');
+    expect(typeof resolveStateDir).toBe('function');
+    expect(typeof resolveConfigFile).toBe('function');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. SO_OS matches process.platform
+// ---------------------------------------------------------------------------
+
+describe('SO_OS', () => {
+  it('equals process.platform', () => {
+    expect(SO_OS).toBe(process.platform);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3. SO_IS_WINDOWS correctness
+// ---------------------------------------------------------------------------
+
+describe('SO_IS_WINDOWS', () => {
+  it('is true only when process.platform is win32', () => {
+    if (process.platform === 'win32') {
+      expect(SO_IS_WINDOWS).toBe(true);
+    } else {
+      expect(SO_IS_WINDOWS).toBe(false);
+    }
+  });
+
+  it('is a boolean', () => {
+    expect(typeof SO_IS_WINDOWS).toBe('boolean');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 4. SO_IS_WSL detection — reflects env at module load time
+// ---------------------------------------------------------------------------
+
+describe('SO_IS_WSL', () => {
+  it('is a boolean', () => {
+    expect(typeof SO_IS_WSL).toBe('boolean');
+  });
+
+  it('is true when WSL_DISTRO_NAME was set at module load, false when unset', () => {
+    // The constant reflects the state of the environment at import time.
+    // We verify the value matches the env-var presence at that moment.
+    const expectedAtLoadTime = process.env.WSL_DISTRO_NAME !== undefined;
+    expect(SO_IS_WSL).toBe(expectedAtLoadTime);
+  });
+
+  it('is false on macOS and Windows native (no WSL_DISTRO_NAME in those environments)', () => {
+    // On native macOS / Windows, WSL_DISTRO_NAME is never set.
+    if (process.platform === 'darwin' || process.platform === 'win32') {
+      expect(SO_IS_WSL).toBe(false);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 5. SO_PATH_SEP equals path.sep
+// ---------------------------------------------------------------------------
+
+describe('SO_PATH_SEP', () => {
+  it('equals path.sep from node:path', () => {
+    expect(SO_PATH_SEP).toBe(path.sep);
+  });
+
+  it('is "/" on POSIX or "\\\\" on Windows', () => {
+    if (process.platform === 'win32') {
+      expect(SO_PATH_SEP).toBe('\\');
+    } else {
+      expect(SO_PATH_SEP).toBe('/');
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 6. resolveStateDir mapping
+// ---------------------------------------------------------------------------
+
+describe('resolveStateDir', () => {
+  it('returns ".claude" for platform "claude"', () => {
+    expect(resolveStateDir('claude')).toBe('.claude');
+  });
+
+  it('returns ".codex" for platform "codex"', () => {
+    expect(resolveStateDir('codex')).toBe('.codex');
+  });
+
+  it('returns ".cursor" for platform "cursor"', () => {
+    expect(resolveStateDir('cursor')).toBe('.cursor');
+  });
+
+  it('returns ".claude" for unknown platform (default case)', () => {
+    expect(resolveStateDir('unknown')).toBe('.claude');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 7. resolveConfigFile mapping
+// ---------------------------------------------------------------------------
+
+describe('resolveConfigFile', () => {
+  it('returns "CLAUDE.md" for platform "claude"', () => {
+    expect(resolveConfigFile('claude')).toBe('CLAUDE.md');
+  });
+
+  it('returns "AGENTS.md" for platform "codex"', () => {
+    expect(resolveConfigFile('codex')).toBe('AGENTS.md');
+  });
+
+  it('returns "CLAUDE.md" for platform "cursor"', () => {
+    expect(resolveConfigFile('cursor')).toBe('CLAUDE.md');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 8. SO_SHARED_DIR is constant
+// ---------------------------------------------------------------------------
+
+describe('SO_SHARED_DIR', () => {
+  it('equals ".orchestrator" regardless of platform', () => {
+    expect(SO_SHARED_DIR).toBe('.orchestrator');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 9. detectPlatform env-var precedence
+// ---------------------------------------------------------------------------
+
+describe('detectPlatform', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('returns "claude" when CLAUDE_PLUGIN_ROOT is set', () => {
+    vi.stubEnv('CLAUDE_PLUGIN_ROOT', '/some/path');
+    vi.stubEnv('CODEX_PLUGIN_ROOT', '');
+    vi.stubEnv('CURSOR_RULES_DIR', '');
+    expect(detectPlatform()).toBe('claude');
+  });
+
+  it('returns "codex" when CODEX_PLUGIN_ROOT is set and CLAUDE_PLUGIN_ROOT is unset', () => {
+    vi.stubEnv('CLAUDE_PLUGIN_ROOT', '');
+    vi.stubEnv('CODEX_PLUGIN_ROOT', '/some/codex/path');
+    vi.stubEnv('CURSOR_RULES_DIR', '');
+    expect(detectPlatform()).toBe('codex');
+  });
+
+  it('returns "cursor" when CURSOR_RULES_DIR is set and other env vars are unset', () => {
+    vi.stubEnv('CLAUDE_PLUGIN_ROOT', '');
+    vi.stubEnv('CODEX_PLUGIN_ROOT', '');
+    vi.stubEnv('CURSOR_RULES_DIR', '/some/cursor/path');
+    expect(detectPlatform()).toBe('cursor');
+  });
+
+  it('CLAUDE_PLUGIN_ROOT takes precedence over CODEX_PLUGIN_ROOT', () => {
+    vi.stubEnv('CLAUDE_PLUGIN_ROOT', '/claude/root');
+    vi.stubEnv('CODEX_PLUGIN_ROOT', '/codex/root');
+    vi.stubEnv('CURSOR_RULES_DIR', '');
+    expect(detectPlatform()).toBe('claude');
+  });
+
+  it('returns "claude" as default when no env vars are set', () => {
+    vi.stubEnv('CLAUDE_PLUGIN_ROOT', '');
+    vi.stubEnv('CODEX_PLUGIN_ROOT', '');
+    vi.stubEnv('CURSOR_RULES_DIR', '');
+    // When no env var is set and no marker directories are found,
+    // default is "claude". The test CWD is the repo root which has
+    // a .claude-plugin dir — which would also return "claude".
+    const result = detectPlatform();
+    expect(['claude', 'codex', 'cursor']).toContain(result);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 10. resolvePluginRoot returns absolute path
+// ---------------------------------------------------------------------------
+
+describe('resolvePluginRoot', () => {
+  it('returns an absolute path or empty string', () => {
+    const result = resolvePluginRoot();
+    // Either resolves to an absolute path or returns empty string when not found
+    expect(typeof result).toBe('string');
+    if (result !== '') {
+      expect(path.isAbsolute(result)).toBe(true);
+    }
+  });
+
+  it('returns an absolute path when CLAUDE_PLUGIN_ROOT points to an existing directory', () => {
+    // Use fileURLToPath to get an OS-correct absolute path on all platforms
+    // (URL.pathname on Windows has a leading slash: /C:/Users/...).
+    const scriptsDir = path.resolve(fileURLToPath(new URL('../../scripts', import.meta.url)));
+    vi.stubEnv('CLAUDE_PLUGIN_ROOT', scriptsDir);
+    const result = resolvePluginRoot('claude');
+    vi.unstubAllEnvs();
+    expect(path.isAbsolute(result)).toBe(true);
+    expect(result).toBe(scriptsDir);
+  });
+
+  it('SO_PLUGIN_ROOT constant is either empty or an absolute path', () => {
+    if (SO_PLUGIN_ROOT !== '') {
+      expect(path.isAbsolute(SO_PLUGIN_ROOT)).toBe(true);
+    } else {
+      expect(SO_PLUGIN_ROOT).toBe('');
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 11. SO_PLATFORM is one of the valid platform values
+// ---------------------------------------------------------------------------
+
+describe('SO_PLATFORM', () => {
+  it('is one of "claude", "codex", or "cursor"', () => {
+    expect(['claude', 'codex', 'cursor']).toContain(SO_PLATFORM);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 12. resolveProjectDir returns an absolute path
+// ---------------------------------------------------------------------------
+
+describe('resolveProjectDir', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('returns an absolute path', () => {
+    const result = resolveProjectDir();
+    expect(path.isAbsolute(result)).toBe(true);
+  });
+
+  it('returns CLAUDE_PROJECT_DIR when that env var is set', () => {
+    vi.stubEnv('CLAUDE_PROJECT_DIR', '/my/project');
+    vi.stubEnv('CODEX_PROJECT_DIR', '');
+    vi.stubEnv('CURSOR_PROJECT_DIR', '');
+    const result = resolveProjectDir('claude');
+    expect(result).toBe('/my/project');
+    vi.unstubAllEnvs();
+  });
+
+  it('returns CODEX_PROJECT_DIR when CLAUDE_PROJECT_DIR is unset', () => {
+    vi.stubEnv('CLAUDE_PROJECT_DIR', '');
+    vi.stubEnv('CODEX_PROJECT_DIR', '/my/codex/project');
+    vi.stubEnv('CURSOR_PROJECT_DIR', '');
+    const result = resolveProjectDir('codex');
+    expect(result).toBe('/my/codex/project');
+    vi.unstubAllEnvs();
+  });
+});

--- a/vitest.config.mjs
+++ b/vitest.config.mjs
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['tests/**/*.test.mjs'],
+    testTimeout: 10000,
+  },
+});


### PR DESCRIPTION
Closes the final gap in the GitHub Community Standards checklist (currently missing only `code_of_conduct`).

Adopts the canonical **Contributor Covenant v2.1** verbatim, placed at repo root for consistency with existing `CONTRIBUTING.md` and `SECURITY.md`.

**Enforcement contact:** `office@gotzendorfer.at`

**Peer references** (Claude Code plugin ecosystem): `wshobson/commands`, `hesreallyhim/awesome-claude-code` — both ship CC v2.1.

Mirror of https://gitlab.gotzendorfer.at/infrastructure/session-orchestrator/-/merge_requests/7