### PR TITLE
fix: quote argument-hint YAML values so Copilot CLI ≥1.0.65 loads all skills (closes #54)

### DIFF
--- a/commands/autopilot-multi.md
+++ b/commands/autopilot-multi.md
@@ -1,6 +1,6 @@
 ---
 description: Multi-story autopilot orchestrator — runs N parallel issue pipelines in isolated git worktrees (v3.6 Phase D thin-slice)
-argument-hint: [--dry-run|--apply] [--max-stories=N] [--max-hours=H] [--inactivity-timeout=S] [--stall-seconds=S] [--draft-mr=off|on-loop-start|on-green] [--json] [--verbose]
+argument-hint: "[--dry-run|--apply] [--max-stories=N] [--max-hours=H] [--inactivity-timeout=S] [--stall-seconds=S] [--draft-mr=off|on-loop-start|on-green] [--json] [--verbose]"
 ---
 
 # Autopilot Multi

--- a/commands/autopilot.md
+++ b/commands/autopilot.md
@@ -1,6 +1,6 @@
 ---
 description: Autonomous session-orchestration loop with kill-switches (Phase C-1.b — all 10 kill-switches shipped)
-argument-hint: [--headless] [--verbose] [--max-sessions=N] [--max-hours=H] [--confidence-threshold=0.X] [--dry-run]
+argument-hint: "[--headless] [--verbose] [--max-sessions=N] [--max-hours=H] [--confidence-threshold=0.X] [--dry-run]"
 ---
 
 # Autopilot

--- a/commands/bootstrap.md
+++ b/commands/bootstrap.md
@@ -1,7 +1,7 @@
 ---
 description: Scaffold the minimum repo structure required by session-orchestrator
 disable-model-invocation: true
-argument-hint: [--upgrade <tier>]
+argument-hint: "[--upgrade <tier>]"
 ---
 
 # Bootstrap

--- a/commands/plan.md
+++ b/commands/plan.md
@@ -1,7 +1,7 @@
 ---
 description: Plan a new project, feature, or retrospective with structured requirement gathering
 disable-model-invocation: true
-argument-hint: [new|feature|retro]
+argument-hint: "[new|feature|retro]"
 ---
 
 # Plan

--- a/commands/session.md
+++ b/commands/session.md
@@ -1,6 +1,6 @@
 ---
 description: Start a development session (housekeeping, feature, deep)
-argument-hint: [housekeeping|feature|deep]
+argument-hint: "[housekeeping|feature|deep]"
 ---
 
 # Session Start

--- a/pi/prompts/autopilot-multi.md
+++ b/pi/prompts/autopilot-multi.md
@@ -1,6 +1,6 @@
 ---
 description: Multi-story autopilot orchestrator — runs N parallel issue pipelines in isolated git worktrees (v3.6 Phase D thin-slice)
-argument-hint: [--dry-run|--apply] [--max-stories=N] [--max-hours=H] [--inactivity-timeout=S] [--stall-seconds=S] [--draft-mr=off|on-loop-start|on-green] [--json] [--verbose]
+argument-hint: "[--dry-run|--apply] [--max-stories=N] [--max-hours=H] [--inactivity-timeout=S] [--stall-seconds=S] [--draft-mr=off|on-loop-start|on-green] [--json] [--verbose]"
 ---
 
 # /autopilot-multi

--- a/pi/prompts/autopilot.md
+++ b/pi/prompts/autopilot.md
@@ -1,6 +1,6 @@
 ---
 description: Autonomous session-orchestration loop with kill-switches (Phase C-1.b — all 10 kill-switches shipped)
-argument-hint: [--headless] [--verbose] [--max-sessions=N] [--max-hours=H] [--confidence-threshold=0.X] [--dry-run]
+argument-hint: "[--headless] [--verbose] [--max-sessions=N] [--max-hours=H] [--confidence-threshold=0.X] [--dry-run]"
 ---
 
 # /autopilot

--- a/pi/prompts/bootstrap.md
+++ b/pi/prompts/bootstrap.md
@@ -1,6 +1,6 @@
 ---
 description: Scaffold the minimum repo structure required by session-orchestrator
-argument-hint: [--upgrade <tier>]
+argument-hint: "[--upgrade <tier>]"
 ---
 
 # /bootstrap

--- a/pi/prompts/plan.md
+++ b/pi/prompts/plan.md
@@ -1,6 +1,6 @@
 ---
 description: Plan a new project, feature, or retrospective with structured requirement gathering
-argument-hint: [new|feature|retro]
+argument-hint: "[new|feature|retro]"
 ---
 
 # /plan

--- a/pi/prompts/session.md
+++ b/pi/prompts/session.md
@@ -1,6 +1,6 @@
 ---
 description: Start a development session (housekeeping, feature, deep)
-argument-hint: [housekeeping|feature|deep]
+argument-hint: "[housekeeping|feature|deep]"
 ---
 
 # /session


### PR DESCRIPTION
Closes #54.

## Summary

Purely mechanical single-character transform to 10 file(s): wrap the value after `argument-hint:` in double quotes so YAML parses it as a **string** instead of a flow-sequence array. Fixes GitHub Copilot CLI ≥ 1.0.65 silently dropping the skill.

```diff
- argument-hint: [foo]
+ argument-hint: "[foo]"
```

Bare `[...]` is YAML flow-sequence syntax → the loader receives `["foo"]` (a list), fails its `str` validation, and rejects the SKILL without an error. Claude Code, VS Code Agent Skills, and every other loader document `argument-hint` as a string; the quoted-string form is what all reference docs show.

## Files (10)

- `pi/prompts/bootstrap.md`
- `pi/prompts/autopilot.md`
- `pi/prompts/autopilot-multi.md`
- `commands/bootstrap.md`
- `commands/autopilot.md`
- `commands/autopilot-multi.md`
- `commands/plan.md`
- `pi/prompts/plan.md`
- `pi/prompts/session.md`
- `commands/session.md`

## Verification

- YAML round-trip via `yaml.safe_load` on every changed frontmatter reports `argument-hint` as `str`
- No vulnerable value contained `"` or `\`, so bare double-quote wrapping is safe

## Sources

- [Claude Code slash-commands / frontmatter reference](https://code.claude.com/docs/en/slash-commands) — `argument-hint` documented as a string
- [VS Code Agent Skills docs](https://code.visualstudio.com/docs/agent-customization/agent-skills) — same
